### PR TITLE
Fix vote command overriding ping command

### DIFF
--- a/commands/vote.js
+++ b/commands/vote.js
@@ -11,7 +11,7 @@ module.exports.run = async (client, message, args, prefix) => {
 };
 
 module.exports.help = {
-    name:"ping",
-    description:"test command for the compiler bot",
+    name:"vote",
+    description:"displays the link to vote for this bot",
     dev: false
 }


### PR DESCRIPTION
Due to their `help.name` values being the same, this command was overriding the implementation of the ping command via the lexicographic assignment of this block https://github.com/Headline/discord-compiler-bot/blob/master/index.js#L40-L44.

```js
jsfiles.forEach((f, i) => {
    let props = require(`./commands/${f}`);
    console.log(`${f} command has been loaded!`);
    client.commands.set(props.help.name, props);
});
```

