### PR TITLE
Fix regression in dev permission sys

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ client.on('message', message => {
     if (commandfile) {
         Statistics.Requests.DoRequest();
 
-        if(commandfile.dev && message.author.id != botconfig.owner_id)
+        if(commandfile.help.dev && message.author.id != botconfig.owner_id)
             return;
 
         commandfile.run(client, message, args, botconfig.prefix, compilerAPI);


### PR DESCRIPTION
Prior to this change, permissions were not being properly checked due to a regression back when dev permissions were just being created. 

The impact for this bug is very minimal, as statistics show that this command was rarely (if-ever) used by end consumers. 