### PR TITLE
Fix typo on stdin args of compile.js

### DIFF
--- a/commands/compile.js
+++ b/commands/compile.js
@@ -39,15 +39,15 @@ module.exports.run = async (client, message, args, prefix, compilerAPI, SupportS
         if (args[i].indexOf('```') > -1) break;
 
         if (args[i] === "|") {
-            argsData.pipeReached = true;
+            argsData.stdinReached = true;
             continue;
         } else if (args[i] === "<") {
             argsData.fileInputReached = true;
             continue;
         }
 
-        if (argsData.pipeReached) {
-            argsData.pipe += args[i] + " ";
+        if (argsData.stdinReached) {
+            argsData.stdin += args[i] + " ";
         } else if (argsData.fileInputReached) {
             argsData.fileInput += args[i] + " ";
         } else {


### PR DESCRIPTION
A bit more info on the commit message body on why, but suffice to say I screwed it up and `stdin` was no longer being passed correctly, so this is the fix for it.