### PR TITLE
Capture Upper-case discord languages

### DIFF
--- a/commands/compile.js
+++ b/commands/compile.js
@@ -138,8 +138,8 @@ module.exports.run = async (client, message, args, prefix, compilerAPI, SupportS
 
     let substr = code.substr(0, stop);
     for (let i = 0; i < discordLanguages.length; i++) {
-        if (substr == discordLanguages[i]) {
-            code = code.replace(discordLanguages[i], '');
+        if (substr.toLowerCase() == discordLanguages[i]) {
+            code = code.replace(substr.toLowerCase(), '');
             break;
         }
     }

--- a/commands/compile.js
+++ b/commands/compile.js
@@ -139,7 +139,7 @@ module.exports.run = async (client, message, args, prefix, compilerAPI, SupportS
     let substr = code.substr(0, stop);
     for (let i = 0; i < discordLanguages.length; i++) {
         if (substr.toLowerCase() == discordLanguages[i]) {
-            code = code.replace(substr.toLowerCase(), '');
+            code = code.replace(substr, '');
             break;
         }
     }


### PR DESCRIPTION
This proposal fixes an issue some users may face where their syntax-highlight-intended language may end up being compiled along with the source.

The example that this fixes is the following
``````
```Java
<code>
```
``````