### PR TITLE
Add semi-flexible fix for broken WandBox compilers

### DIFF
--- a/WandBox.js
+++ b/WandBox.js
@@ -32,10 +32,19 @@ class Compilers {
     initialize() {
         this.compilerinfo = [];
         this.languages = [];
+        
+        // List of compilers WandBox has set up incorrectly and need to be ignored to prevent backend environmental setup errors.
+        this.brokencompilers = ['ghc-head'];
 
         this.compilers.forEach((obj) => {
             let lang = obj.language.toLowerCase();
             let compiler = obj.name;
+            
+            // Skip any broken compilers on WandBox so users cannot accidentally use them.
+            if (this.brokencompilers.includes(compiler)) {
+                return;
+            }
+            
             if (this.languages.indexOf(lang) < 0) {
                 this.languages.push(lang);
                 this.compilerinfo[lang] = [];


### PR DESCRIPTION
- Adds `brokencompilers` list to the `Compilers` class. Any compilers whose name exactly matches a name present in `brokencompilers` will not be loaded for use.

- Implements fix for #15 using the aforementioned change to ignore the broken `ghc-head` Haskell compiler.