### PR TITLE
Fix unhandled exception & improve async stacktraces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "discord-compiler",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A Discord bot that compiles your spaghetti",
   "main": "index.js",
   "scripts": {
     "build": "babel src -d build",
-    "run": "node build/index.js",
+    "run": "node --async-stack-traces build/index.js",
     "start": "babel src -d build && npm run run",
     "clean": "rm -rf `find build -mindepth 1 | grep -v 'getkeep$'`",
     "test": "npm run clean && npm run build && mocha build/tests/*.js"

--- a/src/tests/messagetimeout.test.js
+++ b/src/tests/messagetimeout.test.js
@@ -6,6 +6,13 @@ import MessageTimeout from '../utils/MessageTimeout'
 class testobj {
     constructor(done) {
         this.done = done;
+        this.reactions = {
+            cache: {
+                forEach(funct) {
+                    // fake stub for loop
+                }
+            }
+        }
     }
     stop() {
         this.done();

--- a/src/tests/messagetimeout.test.js
+++ b/src/tests/messagetimeout.test.js
@@ -1,0 +1,27 @@
+import assert from 'assert'
+import "regenerator-runtime/runtime.js";
+
+import MessageTimeout from '../utils/MessageTimeout'
+
+class testobj {
+    constructor(done) {
+        this.done = done;
+    }
+    stop() {
+        this.done();
+    };
+}
+describe('MessageTimeout', function () {
+    this.timeout(6000)
+    it('1 sec timer', function (done)  {
+        let obj = new testobj(done);
+        let timeout = new MessageTimeout(obj, obj, 1);
+        timeout.start()
+    });
+    it('5 sec timer restart', function (done)  {
+        let obj = new testobj(done);
+        let timeout = new MessageTimeout(obj, obj, 5);
+        timeout.start()
+        timeout.restart();
+    });
+});

--- a/src/utils/DiscordMessageMenu.js
+++ b/src/utils/DiscordMessageMenu.js
@@ -217,13 +217,13 @@ class MessageTimeout {
             await message.reactions.cache.forEach(async (reaction) => {
                 reaction.remove(message.author);
             });
-            //await message.reactions.removeAll();
-            collector.stop();    
         }
         catch (err)
         {
-            throw(err);
+            // We failed out here, there's not much to do other then silenty die.
+            // Rethrowing an error here won't propegate up any further...
         }
+        collector.stop();    
     }
 
     restart() {

--- a/src/utils/DiscordMessageMenu.js
+++ b/src/utils/DiscordMessageMenu.js
@@ -118,7 +118,7 @@ export default class DiscordMessageMenu {
                         try {
                             await result.reactions.cache.forEach(async (reaction) => {
                                 await reaction.remove(result.author);
-                            });        
+                            });
                         }
                         catch (error) {
                             throw(error); // throw to higher level

--- a/src/utils/DiscordMessageMenu.js
+++ b/src/utils/DiscordMessageMenu.js
@@ -1,4 +1,6 @@
 import { Message, MessageEmbed } from 'discord.js'
+import MessageTimeout from './MessageTimeout'
+
 /**
  * Discord Embed Menu helper class to make your life easer. It 
  * allows for on-the-fly menus, and is nearly effortless.
@@ -132,7 +134,7 @@ export default class DiscordMessageMenu {
             });
 
             if (first) {
-                this.timeout = new MessageTimeout(result, this.collector);
+                this.timeout = new MessageTimeout(result, this.collector, 30);
                 this.timeout.start();
             }
         }
@@ -185,49 +187,5 @@ export default class DiscordMessageMenu {
         catch (error) {
             throw (error); // give to higher level for handling
         }
-    }
-}
-
-/**
- * Internal timer helper that expires old help command outputs
- */
-class MessageTimeout {
-    constructor(message, collector, delay) {
-        this.message = message;
-        this.collector = collector
-        this.delay = delay;
-        this.timeout = null;
-    }
-
-    start() {
-        this.timeout = setTimeout(this.run, 30 * 1000, this.message, this.collector);
-    }
-
-    stop() {
-        clearTimeout(this.timeout);
-    }
-
-    /**
-     * 
-     * @param {Message} message 
-     * @param {ReactionCollector} collector 
-     */
-    async run(message, collector) {
-        try {
-            await message.reactions.cache.forEach(async (reaction) => {
-                reaction.remove(message.author);
-            });
-        }
-        catch (err)
-        {
-            // We failed out here, there's not much to do other then silenty die.
-            // Rethrowing an error here won't propegate up any further...
-        }
-        collector.stop();    
-    }
-
-    restart() {
-        clearTimeout(this.timeout);
-        this.start();
     }
 }

--- a/src/utils/MessageTimeout.js
+++ b/src/utils/MessageTimeout.js
@@ -1,7 +1,16 @@
+import {Message, ReactionCollector} from 'discord.js'
+
 /**
  * Internal timer helper that expires old help command outputs
  */
 export default class MessageTimeout {
+    /**
+     * Creates a MessageTimeout which handles reaction removal and collection closure
+     * 
+     * @param {Message} message message to remove reactions from after delay
+     * @param {ReactionCollector} collector reaction collector to close after delay
+     * @param {number} delay delay in seconds
+     */
     constructor(message, collector, delay) {
         this.message = message;
         this.collector = collector;
@@ -29,23 +38,18 @@ export default class MessageTimeout {
      * @param {ReactionCollector} collector 
      */
     async run(message, collector) {
-        try {
-            await message.reactions.cache.forEach(async (reaction) => {
-                reaction.remove(message.author);
-            });
-        }
-        catch (err)
-        {
-            // We failed out here, there's not much to do other then silenty die.
-            // Rethrowing an error here won't propegate up any further...
-        }
+        message.reactions.cache.forEach(async (reaction) => {
+            try {
+                await reaction.remove(message.author);
+            }
+            catch (err) {
+                // We failed out here, there's not much to do other than die.
+                // Rethrowing an error here won't propegate up any further...
+                message.client.emit('missingPermissions', message.guild);
+            }
+        });
 
-        try {
-            collector.stop();    
-        }
-        catch (err) {
-            console.log('Collector stop error: ' + err.message);
-        }
+        collector.stop();
     }
 
     restart() {

--- a/src/utils/MessageTimeout.js
+++ b/src/utils/MessageTimeout.js
@@ -1,0 +1,55 @@
+/**
+ * Internal timer helper that expires old help command outputs
+ */
+export default class MessageTimeout {
+    constructor(message, collector, delay) {
+        this.message = message;
+        this.collector = collector;
+        this.delay = delay;
+        this.timeout = null;
+    }
+
+    /**
+     * Starts the message timeout timer
+     */
+    start() {
+        this.timeout = setTimeout(this.run, this.delay * 1000, this.message, this.collector);
+    }
+
+    /**
+     * Stops the message timeout timer
+     */
+    stop() {
+        clearTimeout(this.timeout);
+    }
+
+    /**
+     * 
+     * @param {Message} message 
+     * @param {ReactionCollector} collector 
+     */
+    async run(message, collector) {
+        try {
+            await message.reactions.cache.forEach(async (reaction) => {
+                reaction.remove(message.author);
+            });
+        }
+        catch (err)
+        {
+            // We failed out here, there's not much to do other then silenty die.
+            // Rethrowing an error here won't propegate up any further...
+        }
+
+        try {
+            collector.stop();    
+        }
+        catch (err) {
+            console.log('Collector stop error: ' + err.message);
+        }
+    }
+
+    restart() {
+        clearTimeout(this.timeout);
+        this.start();
+    }
+}


### PR DESCRIPTION
Prior to this patch, we were mistakenly rethrowing exceptions into the caller of setTimeout(), instead of doing this; we can handle it ourselves and report it to logging.