### PR TITLE
Fix TypeError when not tracking stats

### DIFF
--- a/src/commands/compile.js
+++ b/src/commands/compile.js
@@ -118,7 +118,9 @@ export default class CompileCommand extends CompilerCommand {
                 }
             });
         }
-        this.client.stats.compilationExecuted(lang);
+
+        if (this.client.stats)
+            this.client.stats.compilationExecuted(lang);
 
         let embed = this.buildResponseEmbed(msg, json);
         let responsemsg = await msg.dispatch('', embed);


### PR DESCRIPTION
This was a regression from one of the recent patches, fixes #27 

