### PR TITLE
Adjust message split offset to prevent request failures

### DIFF
--- a/src/commands/asm.js
+++ b/src/commands/asm.js
@@ -273,11 +273,11 @@ export default class AsmCommand extends CompilerCommand {
             // This kinda sucks, to show full assembly output we'll need to split our fields into
             // reasonbly-sized chunks. Sanity resumes after this if statement.
             let message = json.program_message;
-            if (message.length > 1011) {
+            if (message.length > 1010) {
                 let count = 1;
-                while (message.length > 1011 && embed.length+1024< 6000) {
+                while (message.length > 1010 && embed.length+1024< 6000) {
                     let nearest_newline = 0;
-                    for(let i = 1011; i > 0; i--) {
+                    for(let i = 1010; i > 0; i--) {
                         if (message[i] == '\n') {
                             nearest_newline = i;
                             break;


### PR DESCRIPTION
Off-by-one error for the search offset that resulted in certain message embed fields from being > 1024 characters. This caused certain requests to fail and left users confused with the resulting error message.