### PR TITLE
NPOTB: Add support for tracking failed compilations

### DIFF
--- a/src/commands/compile.js
+++ b/src/commands/compile.js
@@ -111,13 +111,12 @@ export default class CompileCommand extends CompilerCommand {
 
         SupportServer.postCompilation(code, lang, json.url, msg.message.author, msg.message.guild, json.status == 0, json.compiler_message, this.client.compile_log, this.client.token);
 
-
-        if (this.client.shouldTrackStats())
-            this.client.stats.compilationExecuted(lang);
-
         let embed = CompileCommand.buildResponseEmbed(msg, json);
         let responsemsg = await msg.dispatch('', embed);
         
+        if (this.client.shouldTrackStats())
+            this.client.stats.compilationExecuted(lang, embed.color == 0xFF0000);
+
         try {
             responsemsg.react((embed.color == 0xFF0000)?'❌':'✅');
         }

--- a/src/utils/apis/StatisticsTracking.js
+++ b/src/utils/apis/StatisticsTracking.js
@@ -69,8 +69,9 @@ export class StatisticsAPI {
      * Informs the API which language has just been compiled
      * 
      * @param {string} lang langauge compiled
+     * @param {boolean} failure indicates whether it was a failed compilation
      */
-    async compilationExecuted(lang) {
+    async compilationExecuted(lang, failure) {
         // if we were given a compiler we need to find the langauge
         if (!this.client.wandbox.has(lang)) {
             this.client.wandbox.forEach((value, key, map) => {
@@ -83,7 +84,8 @@ export class StatisticsAPI {
         try {
             let obj = {
                 key: this.key,
-                language: lang
+                language: lang,
+                fail: failure
             };
 
             const response = await fetch(this.url + 'insert/language', {


### PR DESCRIPTION
This patch goes in tandem with some adjustments to the [statistics website](https://headlinedev.xyz/discord-compiler).

We can now calculate what the compilation failure percentage is for each language. 