### PR TITLE
Add CompilationFixer to fix user errors for them

### DIFF
--- a/src/CompilerClient.js
+++ b/src/CompilerClient.js
@@ -5,6 +5,7 @@ import MessageRouter from './commands/utils/MessageRouter'
 import { Wandbox } from './utils/apis/Wandbox'
 import { StatisticsAPI } from './utils/apis/StatisticsTracking'
 import { Godbolt } from './utils/apis/Godbolt'
+import { CompilationFixer } from './utils/CompilationFixer'
 
 /**
  * discord.js client with added utility for general bot operations
@@ -39,13 +40,21 @@ export default class CompilerClient extends Client {
 
     /**
      * Setup compilers cache
+     * @type {Wandbox}
      */
     this.wandbox = new Wandbox(this);
 
     /**
      * Setup godbolt cache
+     * @type {Godbolt}
      */
     this.godbolt = new Godbolt(this);
+
+    /**
+     * Setup automated code fixer
+     * @type {CompilationFixer}
+     */
+    this.fixer = new CompilationFixer();
 
     /**
      * Determines whether the bot is in maitenance mode

--- a/src/commands/compile.js
+++ b/src/commands/compile.js
@@ -73,6 +73,7 @@ export default class CompileCommand extends CompilerCommand {
         }
 
         let setup = new WandboxSetup(code, lang, argsData.stdin, true, argsData.options, this.client.wandbox);
+        setup.fix(this.client.fixer); // can we recover a failed compilation?
 
         let reactionSuccess = false;
         if (this.client.loading_emote)

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -26,6 +26,7 @@ export default class HelpCommand extends CompilerCommand {
     async run(msg) {
         let args = msg.getArgs();
 
+        this.help()
         // Lookup command by name if we got a name
         if (args.length > 0) {
             const command = args[0].toLowerCase();

--- a/src/utils/CompilationFixer.js
+++ b/src/utils/CompilationFixer.js
@@ -1,0 +1,39 @@
+import { Client, Collection } from 'discord.js'
+
+
+/**
+ * Helper class to handle regex replacement
+ */
+export class FixerEntry {
+    /**
+     * Creates a fixer entry
+     * @param {RegExp} regex 
+     * @param {string} replace 
+     */
+    constructor(regex, replace) {
+        this.regex = regex;
+        this.replace = replace;
+    }
+
+    /**
+     * Performs a regex replacement, fixing the input string.
+     * @param {string} string replaced str
+     */
+    fix(string) {
+        return string.replace(this.regex, this.replace);
+    }
+};
+
+/**
+ * Helper class to try and catch common compilation errors unique to this environment
+ * 
+ * @extends {Collection}
+ */
+export class CompilationFixer extends Collection {
+    constructor(client) {
+        super();
+
+        let fixer = new FixerEntry(/public (class)/g, '$1');
+        this.set('java', [fixer]);
+    }
+}


### PR DESCRIPTION
This patch is one that I have had in the back of my mind for quite some time. I dislike the idea of modifying user's code without telling them, but the failure rate of Java compilations below is enough reason to motivate me to move forward with this patch.

![Screenshot from 2020-06-23 22-44-11](https://user-images.githubusercontent.com/11095737/85505437-2992ba80-b5a3-11ea-9d4c-a05322b838ed.png)

We now will replace `public class Name {...}` to `class Name {....}` in order to prevent these unnecessary failures. Furthermore, I've created a fairly simple system for further replacements to occur, hopefully there's not many more we'd add, but this is a good start towards decreasing compilation failures