### PR TITLE
Fix failed parse when language isn't delimited

### DIFF
--- a/src/commands/compile.js
+++ b/src/commands/compile.js
@@ -35,6 +35,8 @@ export default class CompileCommand extends CompilerCommand {
 		}
 		
         let lang = args[0].toLowerCase();
+        let index = lang.search("`");
+        lang = (index < 0) ? lang : lang.slice(0, index);
         args.shift();
 
         if (!this.client.wandbox.isValidCompiler(lang) && !this.client.wandbox.has(lang)) {

--- a/src/commands/utils/CompilationParser.js
+++ b/src/commands/utils/CompilationParser.js
@@ -31,7 +31,21 @@ export default class CompilationParser {
      */
     parseArguments() {
         let args = this.message.getArgs();
+        
+        // allows non-delimited compiler/code-block parsing (Ex: ;compile lang```lang ...)
+        let index = args[0].search('`');
+        if (index > 0) {
+            // if this situation occurs, we need to split up arg[0] into the lang and code-block manually
+            let lang = args[0].slice(0, index);
+            
+            // put the first half of the code-block and lang back into the arguments
+            args.splice(1, 0, args[0].slice(index, args[0].length));
+            args[0] = lang;
+        }
+        
+        // we don't handle language parsing here so get rid of it (for now)
         args.shift();
+        
         let argsData = {
             options: "",
             fileInput: "",


### PR DESCRIPTION
Fixes #42 