### PR TITLE
Set memory limit to 512MB

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ dotenv.config();
 
 const manager = new ShardingManager('./build/bot.js', { 
 	token: process.env.BOT_TOKEN,
-	execArgv: ['--async-stack-traces']
+	execArgv: ['--async-stack-traces', '--max-old-space-size=256']
 });
 
 /**


### PR DESCRIPTION
Node.js will spend more time in garbage collection as it reaches this set limit. Lately I've been experimenting with node.js and memory limits, this change is certainly experimental to force garbage collection earlier rather than later.
