### PR TITLE
Add rs to language list

### DIFF
--- a/src/commands/utils/CompilationParser.js
+++ b/src/commands/utils/CompilationParser.js
@@ -125,7 +125,7 @@ export default class CompilationParser {
         "mel", "mercury", "mipsasm", "mizar", "mojolicious", "monkey", "moonscript", "n1ql",
         "nginx", "nimrod", "nix", "nsis", "objectivec", "ocaml", "openscad", "oxygene",
         "parser3", "perl", "pf", "php", "pony", "powershell", "processing", "profile",
-        "prolog", "protobuf", "puppet", "purebasic", "python", "py", "q", "qml", "r", "rib",
+        "prolog", "protobuf", "puppet", "purebasic", "python", "py", "q", "qml", "r", "rs", "rib",
         "roboconf", "routeros", "rsl", "ruby", "ruleslanguage", "rust", "scala", "scheme",
         "scilab", "scss", "shell", "smali", "smalltalk", "sml", "sqf", "sql", "stan", "stata",
         "step21", "stylus", "subunit", "swift", "taggerscript", "tap", "tcl", "tex", "thrift",


### PR DESCRIPTION
Fixes #50 

Our list of discord markdown language codes isn't complete, so sometimes new or otherwise undiscovered language codes become error cases for otherwise successful compilations. 