### PR TITLE
Improve stdin parsing

### DIFF
--- a/src/commands/utils/CompilationParser.js
+++ b/src/commands/utils/CompilationParser.js
@@ -79,11 +79,19 @@ export default class CompilationParser {
             }
             // pipe operator should be last, everything after it should be stdin
             else if (current == '|') {
-                do {
-                    args.shift(); // kill previous
-                    current = args[0];
-                    argsData.stdin += current + ' ';
-                } while (args.length > 1 && !args[1].includes('```'));
+                const regex = /```([\s\S]*?)```/g;
+                regex.lastIndex = this.message.message.content.search('|');
+                let match = regex.exec(this.message.message.content);
+                if (match && (this.getStdinBlockFromText() || argsData.fileInput)) {
+                    argsData.stdin = match[0].substring(3, match[0].length - 3);
+                } else {
+                    do {
+                        args.shift(); // kill previous
+                        current = args[0];
+                        argsData.stdin += current + ' ';
+                    } while (args.length > 1 && !args[1].includes('```'));  
+                }
+
                 args = []; // stop parsing
             }
             // anything else should just be an option

--- a/src/tests/compile.test.js
+++ b/src/tests/compile.test.js
@@ -39,10 +39,32 @@ describe('Compile Command', function() {
         assert.strictEqual(argsData.fileInput, url);
         assert.strictEqual(argsData.stdin, 'testing 1 2 3');
     });
+    it('Parse all url - code block stdin', () => {
+        let url = 'http://michaelwflaherty.com/files/conversation.txt';
+        let stdin = 'testing 1 2 3';
+        let options = '-O3 -std=c++11 -fake-flag1 -fake-flag2';
+        fakeMessage.content = `;compile c++ ${options} < ${url} | \`\`\`
+${stdin}\`\`\``
+        let argsData = parser.parseArguments();
+
+        assert.strictEqual(argsData.options, options);
+        assert.strictEqual(argsData.fileInput, url);
+        assert.strictEqual(argsData.stdin, 'testing 1 2 3');
+    });
     it('Parse all standard', () => {
         let stdin = 'testing 1 2 3';
         let options = '-O3 -std=c++11 -fake-flag1 -fake-flag2';
         fakeMessage.content = `;compile c++ ${options} | ${stdin}`
+        let argsData = parser.parseArguments();
+
+        assert.strictEqual(argsData.options, options);
+        assert.strictEqual(argsData.stdin, 'testing 1 2 3');
+    });
+    it('Parse all standard - code block stdin', () => {
+        let stdin = 'testing 1 2 3';
+        let options = '-O3 -std=c++11 -fake-flag1 -fake-flag2';
+        fakeMessage.content = `;compile c++ ${options} | \`\`\`
+${stdin}\`\`\``
         let argsData = parser.parseArguments();
 
         assert.strictEqual(argsData.options, options);

--- a/src/tests/compile.test.js
+++ b/src/tests/compile.test.js
@@ -43,8 +43,7 @@ describe('Compile Command', function() {
         let url = 'http://michaelwflaherty.com/files/conversation.txt';
         let stdin = 'testing 1 2 3';
         let options = '-O3 -std=c++11 -fake-flag1 -fake-flag2';
-        fakeMessage.content = `;compile c++ ${options} < ${url} | \`\`\`
-${stdin}\`\`\``
+        fakeMessage.content = `;compile c++ ${options} < ${url} | \`\`\`\n${stdin}\`\`\``
         let argsData = parser.parseArguments();
 
         assert.strictEqual(argsData.options, options);
@@ -54,7 +53,7 @@ ${stdin}\`\`\``
     it('Parse all standard', () => {
         let stdin = 'testing 1 2 3';
         let options = '-O3 -std=c++11 -fake-flag1 -fake-flag2';
-        fakeMessage.content = `;compile c++ ${options} | ${stdin}`
+        fakeMessage.content = `;compile c++ ${options} | ${stdin}\n\`\`\`cpp\nint main() {}\n\`\`\``
         let argsData = parser.parseArguments();
 
         assert.strictEqual(argsData.options, options);
@@ -63,8 +62,7 @@ ${stdin}\`\`\``
     it('Parse all standard - code block stdin', () => {
         let stdin = 'testing 1 2 3';
         let options = '-O3 -std=c++11 -fake-flag1 -fake-flag2';
-        fakeMessage.content = `;compile c++ ${options} | \`\`\`
-${stdin}\`\`\``
+        fakeMessage.content = `;compile c++ ${options} | \`\`\`\n${stdin}\`\`\`\n\`\`\`cpp\nint main() {}\n\`\`\``
         let argsData = parser.parseArguments();
 
         assert.strictEqual(argsData.options, options);


### PR DESCRIPTION
These changes attempt to make the parser more versatile when handling stdin. This should allow for stdin to work with or without code block formatting and when using a code URL.