### PR TITLE
Add support for requests tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "discord-compiler-bot"
-version = "3.0.0-rc.0"
+version = "3.0.0-rc.1"
 dependencies = [
  "chrono",
  "dbl-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "discord-compiler-bot"
 description = "Discord bot to compile your spaghetti code."
-version = "3.0.0-rc.0"
+version = "3.0.0-rc.1"
 authors = ["Michael Flaherty (Headline#9999)"]
 edition = "2018"
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -133,6 +133,17 @@ impl EventHandler for Handler {
 }
 
 #[hook]
+pub async fn before(ctx: &Context, _: &Message, _: &str) -> bool {
+    let data = ctx.data.read().await;
+    let stats = data.get::<Stats>().unwrap().lock().await;
+    if stats.should_track() {
+        stats.post_request().await;
+    }
+
+    true
+}
+
+#[hook]
 pub async fn after(
     ctx: &Context,
     msg: &Message,

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let prefix = env::var("BOT_PREFIX")?;
     let framework = StandardFramework::new()
         .configure(|c| c.owners(owners).prefix(&prefix))
+        .before(events::before)
         .after(events::after)
         .group(&GENERAL_GROUP)
         .bucket("nospam", |b| b.delay(3).time_span(10).limit(3))

--- a/src/stats/statsmanager.rs
+++ b/src/stats/statsmanager.rs
@@ -53,6 +53,11 @@ impl StatsManager {
         self.send_request::<LegacyRequest>(&mut legacy).await;
     }
 
+    pub async fn post_request(&self) {
+        let mut legacy = LegacyRequest::new(None);
+        self.send_request::<LegacyRequest>(&mut legacy).await;
+    }
+
     async fn send_request<T: Sendable + std::marker::Sync>(&self, sendable: &mut T) {
         sendable.set_key(&self.pass);
         match sendable.send(self.client.clone(), &self.url).await {


### PR DESCRIPTION
This must have slipped my mind - requests tracking on the [site](https://headlinedev.xyz/discord-complier) has not been working for the past few days. Turns out, it was never completely implemented.

This will bring requests collections back