### PR TITLE
Fix top.gg services issues

### DIFF
--- a/src/apis/dbl.rs
+++ b/src/apis/dbl.rs
@@ -86,7 +86,7 @@ impl BotsListAPI {
             .recover(custom_error);
 
         info!("Starting webhook");
-        warp::serve(webhook).run(([127, 0, 0, 1], port)).await;
+        warp::serve(webhook).run(([0, 0, 0, 0], port)).await;
     }
 
     fn send_vote(user_id: u64, vote_channel: u64, http: Arc<Http>, data: Arc<RwLock<TypeMap>>) {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -35,7 +35,7 @@ impl TypeMapKey for DBLApi {
 
 pub struct ShardServers;
 impl TypeMapKey for ShardServers {
-    type Value = Arc<Mutex<Vec<usize>>>;
+    type Value = Arc<Mutex<Vec<u64>>>;
 }
 
 pub struct Stats;

--- a/src/stats/statsmanager.rs
+++ b/src/stats/statsmanager.rs
@@ -8,7 +8,7 @@ pub struct StatsManager {
     client: Arc<reqwest::Client>,
     url: String,
     pass: String,
-    servers: usize,
+    servers: u64,
 }
 
 impl StatsManager {
@@ -35,7 +35,7 @@ impl StatsManager {
         self.send_request::<CommandRequest>(&mut cmd).await;
     }
 
-    pub async fn post_servers(&mut self, amount: usize) {
+    pub async fn post_servers(&mut self, amount: u64) {
         self.servers = amount;
         let mut legacy = LegacyRequest::new(Some(amount));
         self.send_request::<LegacyRequest>(&mut legacy).await;

--- a/src/stats/structures.rs
+++ b/src/stats/structures.rs
@@ -80,10 +80,10 @@ pub struct LegacyRequest {
     #[serde(rename = "type")]
     request_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    amount: Option<usize>,
+    amount: Option<u64>,
 }
 impl LegacyRequest {
-    pub fn new(amount: Option<usize>) -> LegacyRequest {
+    pub fn new(amount: Option<u64>) -> LegacyRequest {
         let request_type;
         if amount.is_some() {
             request_type = "servers"


### PR DESCRIPTION
We were not receiving any vote stats top.gg due to the fact that we were binding the webhook on 127.0.0.1 (oops). 

Furthermore, we've had all the information necessary to post server/shard count to top.gg, but it just hasn't been implemented before this patch. Now, top.gg should be receiving everything necessary to accurately track us.