### PR TITLE
Only execute clippy analysis on own workspace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --all-targets --target=${{ matrix.target }} -- -D warnings
+          args: --all-targets --all-features --target=${{ matrix.target }} -- -D warnings
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}


### PR DESCRIPTION
Clippy has been checking all dependencies along with our own. This should also speed up our actions execution.