### PR TITLE
Fix incorrect OS names in package script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest-stable
+          - os: ubuntu-latest
             artifact_name: discord-compiler-bot
-          - os: windows-latest-stable
+          - os: windows-latest
             artifact_name: discord-compiler-bot.exe
 
     steps:


### PR DESCRIPTION
This was a mistake in #62 

We now use the supported [actions OS names](https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners#supported-runners-and-hardware-resources).