### PR TITLE
Recover from failed application info requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ GITHUB_LINK=https://github.com/Headline/discord-compiler
 STATS_LINK=http://headlinedev.xyz/discord-compiler
 
 # Optional variables
+BOT_ID=
 COMPILE_LOG=
 JOIN_LOG=
 VOTE_CHANNEL=

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             (owners, info.id)
         }
-        Err(why) => panic!("Could not access application info: {:?}", why),
+        Err(why) => {
+            warn!("Could not access application info: {:?}", why);
+            warn!("Trying environment variable for bot id...");
+            let id = env::var("BOT_ID").expect("Unable to find BOT_ID environment variable");
+            let bot_id = id.parse::<u64>().expect("Invalid bot id");
+            (HashSet::new(), serenity::model::id::UserId(bot_id))
+        },
     };
 
     info!(


### PR DESCRIPTION
Instead of exiting with a panic upon not being able to retrieve our application info, we can recover if we have the bot's user ID. 

The bot's user ID is used to dispatch messages manually and is required to be available through some means, so we can fall back on an optional environment variable here.

This was discovered to be necessary today after a DNS lookup to discord failed.