### PR TITLE
Globalize presence updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ description = "Discord bot to compile your spaghetti code."
 version = "3.0.0-rc.2"
 authors = ["Michael Flaherty (Headline#9999)"]
 edition = "2018"
+build = "src/build.rs"
 
 [dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/src/apis/dbl.rs
+++ b/src/apis/dbl.rs
@@ -13,7 +13,7 @@ use warp::{
 use dbl::types::Webhook;
 use futures_util::future;
 
-use crate::cache::DBLApi;
+use crate::cache::DBLCache;
 use crate::utls::discordhelpers;
 
 pub struct BotsListAPI {
@@ -92,7 +92,7 @@ impl BotsListAPI {
     fn send_vote(user_id: u64, vote_channel: u64, http: Arc<Http>, data: Arc<RwLock<TypeMap>>) {
         tokio::spawn(async move {
             let read = data.read().await;
-            let client_lock = read.get::<DBLApi>().expect("Unable to find dbl data");
+            let client_lock = read.get::<DBLCache>().expect("Unable to find dbl data");
             let awd = client_lock.read().await;
 
             let usr = match awd.user(user_id).await {

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+fn main() {
+    let long = get_github_build(false);
+    let short = get_github_build(true);
+    println!("cargo:rustc-env=GIT_HASH_LONG={}", long);
+    println!("cargo:rustc-env=GIT_HASH_SHORT={}", short);
+}
+
+pub fn get_github_build(short: bool) -> String {
+    let mut args = vec!["rev-parse"];
+    if short {
+        args.push("--short");
+    }
+
+    args.push("HEAD");
+    if let Ok(output) = Command::new("git").args(&args).output() {
+        String::from_utf8(output.stdout).unwrap()
+    } else {
+        String::new()
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -15,40 +15,51 @@ use wandbox::Wandbox;
 use serenity::client::bridge::gateway::ShardManager;
 
 /** Caching **/
+
+/// Contains bot configuration information provided mostly from environment variables
 pub struct ConfigCache;
 impl TypeMapKey for ConfigCache {
     type Value = Arc<RwLock<HashMap<&'static str, String>>>;
 }
 
+/// The cache of all compilers/languages from wandbox - along with our bindings for their api
 pub struct WandboxCache;
 impl TypeMapKey for WandboxCache {
     type Value = Arc<RwLock<Wandbox>>;
 }
+
+/// Same as WandBox cache, but this time it's Matthew's toys
 pub struct GodboltCache;
 impl TypeMapKey for GodboltCache {
     type Value = Arc<RwLock<Godbolt>>;
 }
 
+/// Contains our top.gg api client for server count updates
 pub struct DBLCache;
 impl TypeMapKey for DBLCache {
     type Value = Arc<RwLock<dbl::Client>>;
 }
 
+/// Server count on boot, each shard has their own entry and server count
+//TODO: This should die eventually
 pub struct ServerCountCache;
 impl TypeMapKey for ServerCountCache {
     type Value = Arc<Mutex<Vec<u64>>>;
 }
 
+/// Our endpoints for the in-house statistics tracing - see apis/dbl.rs
 pub struct StatsManagerCache;
 impl TypeMapKey for StatsManagerCache {
     type Value = Arc<Mutex<StatsManager>>;
 }
 
+/// Internal blocklist for abusive users or guilds
 pub struct BlocklistCache;
 impl TypeMapKey for BlocklistCache {
     type Value = Arc<RwLock<Blocklist>>;
 }
 
+/// Contains the shard manager - used to send global presence updates
 pub struct ShardManagerCache;
 impl TypeMapKey for ShardManagerCache {
     type Value = Arc<tokio::sync::Mutex<ShardManager>>;
@@ -106,7 +117,6 @@ pub async fn fill(
         info!("Statistics tracking enabled");
     }
     data.insert::<StatsManagerCache>(Arc::new(Mutex::new(stats)));
-
 
     // Blocklist
     let blocklist = Blocklist::new();

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -15,42 +15,42 @@ use wandbox::Wandbox;
 use serenity::client::bridge::gateway::ShardManager;
 
 /** Caching **/
-pub struct BotInfo;
-impl TypeMapKey for BotInfo {
+pub struct ConfigCache;
+impl TypeMapKey for ConfigCache {
     type Value = Arc<RwLock<HashMap<&'static str, String>>>;
 }
 
-pub struct WandboxInfo;
-impl TypeMapKey for WandboxInfo {
+pub struct WandboxCache;
+impl TypeMapKey for WandboxCache {
     type Value = Arc<RwLock<Wandbox>>;
 }
-pub struct GodboltInfo;
-impl TypeMapKey for GodboltInfo {
+pub struct GodboltCache;
+impl TypeMapKey for GodboltCache {
     type Value = Arc<RwLock<Godbolt>>;
 }
 
-pub struct DBLApi;
-impl TypeMapKey for DBLApi {
+pub struct DBLCache;
+impl TypeMapKey for DBLCache {
     type Value = Arc<RwLock<dbl::Client>>;
 }
 
-pub struct ShardServers;
-impl TypeMapKey for ShardServers {
+pub struct ServerCountCache;
+impl TypeMapKey for ServerCountCache {
     type Value = Arc<Mutex<Vec<u64>>>;
 }
 
-pub struct Stats;
-impl TypeMapKey for Stats {
+pub struct StatsManagerCache;
+impl TypeMapKey for StatsManagerCache {
     type Value = Arc<Mutex<StatsManager>>;
 }
 
-pub struct BlockListInfo;
-impl TypeMapKey for BlockListInfo {
+pub struct BlocklistCache;
+impl TypeMapKey for BlocklistCache {
     type Value = Arc<RwLock<Blocklist>>;
 }
 
-pub struct ShardManagerInfo;
-impl TypeMapKey for ShardManagerInfo {
+pub struct ShardManagerCache;
+impl TypeMapKey for ShardManagerCache {
     type Value = Arc<tokio::sync::Mutex<ShardManager>>;
 }
 
@@ -71,10 +71,10 @@ pub async fn fill(
     map.insert("JOIN_LOG", env::var("JOIN_LOG")?);
     map.insert("BOT_PREFIX", String::from(prefix));
     map.insert("BOT_ID", id.to_string());
-    data.insert::<BotInfo>(Arc::new(RwLock::new(map)));
+    data.insert::<ConfigCache>(Arc::new(RwLock::new(map)));
 
     // Shard manager for universal presence
-    data.insert::<ShardManagerInfo>(shard_manager);
+    data.insert::<ShardManagerCache>(shard_manager);
 
     // Wandbox
     let mut broken_compilers = std::collections::HashSet::new();
@@ -83,32 +83,32 @@ pub async fn fill(
     broken_languages.insert(String::from("cpp"));
     let wbox = wandbox::Wandbox::new(Some(broken_compilers), Some(broken_languages)).await?;
     info!("WandBox cache loaded");
-    data.insert::<WandboxInfo>(Arc::new(RwLock::new(wbox)));
+    data.insert::<WandboxCache>(Arc::new(RwLock::new(wbox)));
 
     // Godbolt
     let godbolt = Godbolt::new().await?;
     info!("Godbolt cache loaded");
-    data.insert::<GodboltInfo>(Arc::new(RwLock::new(godbolt)));
+    data.insert::<GodboltCache>(Arc::new(RwLock::new(godbolt)));
 
     // DBL
     let token = env::var("DBL_TOKEN")?;
     let client = dbl::Client::new(token)?;
-    data.insert::<DBLApi>(Arc::new(RwLock::new(client)));
+    data.insert::<DBLCache>(Arc::new(RwLock::new(client)));
 
     // DBL
-    data.insert::<ShardServers>(Arc::new(Mutex::new(Vec::new())));
+    data.insert::<ServerCountCache>(Arc::new(Mutex::new(Vec::new())));
 
     // Stats tracking
     let stats = StatsManager::new();
     if stats.should_track() {
         info!("Statistics tracking enabled");
     }
-    data.insert::<Stats>(Arc::new(Mutex::new(stats)));
+    data.insert::<StatsManagerCache>(Arc::new(Mutex::new(stats)));
 
 
     // Blocklist
     let blocklist = Blocklist::new();
-    data.insert::<BlockListInfo>(Arc::new(RwLock::new(blocklist)));
+    data.insert::<BlocklistCache>(Arc::new(RwLock::new(blocklist)));
 
     Ok(())
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -68,6 +68,8 @@ pub async fn fill(
     map.insert("SUCCESS_EMOJI_NAME", env::var("SUCCESS_EMOJI_NAME")?);
     map.insert("LOADING_EMOJI_ID", env::var("LOADING_EMOJI_ID")?);
     map.insert("LOADING_EMOJI_NAME", env::var("LOADING_EMOJI_NAME")?);
+    map.insert("GIT_HASH_LONG", String::from(env!("GIT_HASH_LONG")));
+    map.insert("GIT_HASH_SHORT", String::from(env!("GIT_HASH_SHORT")));
     map.insert("JOIN_LOG", env::var("JOIN_LOG")?);
     map.insert("BOT_PREFIX", String::from(prefix));
     map.insert("BOT_ID", id.to_string());

--- a/src/commands/asm.rs
+++ b/src/commands/asm.rs
@@ -7,7 +7,7 @@ use serenity_utils::menu::Menu;
 
 use godbolt::*;
 
-use crate::cache::{BotInfo, GodboltInfo};
+use crate::cache::{GodboltCache, ConfigCache};
 use crate::utls::constants::*;
 use crate::utls::parser::*;
 use crate::utls::{discordhelpers, parser};
@@ -26,7 +26,7 @@ pub async fn asm(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
 
     // aquire lock to our godbolt cache
     let data_read = ctx.data.read().await;
-    let godbolt_lock = match data_read.get::<GodboltInfo>() {
+    let godbolt_lock = match data_read.get::<GodboltCache>() {
         Some(l) => l,
         None => {
             return Err(CommandError::from(
@@ -121,7 +121,7 @@ pub async fn asm(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
 #[command]
 async fn compilers(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
     let data_read = ctx.data.read().await;
-    let godbolt_lock = match data_read.get::<GodboltInfo>() {
+    let godbolt_lock = match data_read.get::<GodboltCache>() {
         Some(l) => l,
         None => {
             return Err(CommandError::from(
@@ -153,7 +153,7 @@ async fn compilers(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
     {
         let data_read = ctx.data.read().await;
         let botinfo_lock = data_read
-            .get::<BotInfo>()
+            .get::<ConfigCache>()
             .expect("Expected BotInfo in global cache")
             .clone();
         let botinfo = botinfo_lock.read().await;
@@ -211,7 +211,7 @@ async fn compilers(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
 #[command]
 async fn languages(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     let data_read = ctx.data.read().await;
-    let godbolt_lock = match data_read.get::<GodboltInfo>() {
+    let godbolt_lock = match data_read.get::<GodboltCache>() {
         Some(l) => l,
         None => {
             return Err(CommandError::from(
@@ -233,7 +233,7 @@ async fn languages(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     {
         let data_read = ctx.data.read().await;
         let botinfo_lock = data_read
-            .get::<BotInfo>()
+            .get::<ConfigCache>()
             .expect("Expected BotInfo in global cache")
             .clone();
         let botinfo = botinfo_lock.read().await;

--- a/src/commands/block.rs
+++ b/src/commands/block.rs
@@ -2,7 +2,7 @@ use serenity::framework::standard::{macros::command, Args, CommandResult, Comman
 use serenity::model::prelude::*;
 use serenity::prelude::*;
 
-use crate::cache::BlockListInfo;
+use crate::cache::BlocklistCache;
 
 #[command]
 #[owners_only]
@@ -14,7 +14,7 @@ pub async fn block(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
     let arg = args.parse::<u64>()?;
 
     let data = ctx.data.read().await;
-    let mut blocklist = data.get::<BlockListInfo>().unwrap().write().await;
+    let mut blocklist = data.get::<BlocklistCache>().unwrap().write().await;
 
     blocklist.block(arg);
 

--- a/src/commands/botinfo.rs
+++ b/src/commands/botinfo.rs
@@ -4,7 +4,6 @@ use serenity::model::prelude::*;
 use serenity::prelude::*;
 
 use std::env;
-use std::process::Command;
 
 use crate::cache::ConfigCache;
 use crate::utls::constants::COLOR_OKAY;
@@ -15,6 +14,8 @@ pub async fn botinfo(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     let topgg = env::var("DISCORDBOTS_LINK").expect("Expected top.gg link envvar");
     let github = env::var("GITHUB_LINK").expect("Expected github link envvar");
     let stats = env::var("STATS_LINK").expect("Expected stats link envvar");
+    let hash_short = env::var("GIT_HASH_SHORT").expect("Expected stats link envvar");
+    let hash_long = env::var("GIT_HASH_LONG").expect("Expected stats link envvar");
 
     let avatar = {
         let data_read = ctx.data.read().await;
@@ -53,12 +54,9 @@ pub async fn botinfo(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
                 e.thumbnail(avatar);
                 e.color(COLOR_OKAY);
 
-                let hash = get_github_build(false);
-                let short = get_github_build(true);
-                let str = format!(
-                    "Built from commit [{}]({}{}{})",
-                    short, github, "/commit/", hash
-                );
+                let str = format!("Built from commit [{}]({}{}{})",
+                                  hash_short, github, "/commit/", hash_long);
+
                 e.fields(vec![
                     ("Language", "Rust 2018", false),
                     ("Software Version", env!("CARGO_PKG_VERSION"), false),
@@ -77,16 +75,4 @@ pub async fn botinfo(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
 
     debug!("Command executed");
     Ok(())
-}
-
-pub fn get_github_build(short: bool) -> String {
-    // note: add error checking yourself.
-    let mut args = vec!["rev-parse"];
-    if short {
-        args.push("--short");
-    }
-
-    args.push("HEAD");
-    let output = Command::new("git").args(&args).output().unwrap();
-    String::from_utf8(output.stdout).unwrap()
 }

--- a/src/commands/botinfo.rs
+++ b/src/commands/botinfo.rs
@@ -3,8 +3,11 @@ use serenity::framework::standard::{macros::command, Args, CommandResult};
 use serenity::model::prelude::*;
 use serenity::prelude::*;
 
-use crate::cache::BotInfo;
 use std::env;
+use std::process::Command;
+
+use crate::cache::ConfigCache;
+use crate::utls::constants::COLOR_OKAY;
 
 #[command]
 pub async fn botinfo(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
@@ -16,8 +19,8 @@ pub async fn botinfo(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     let avatar = {
         let data_read = ctx.data.read().await;
         let botinfo_lock = data_read
-            .get::<BotInfo>()
-            .expect("Expected BotInfo in global cache")
+            .get::<ConfigCache>()
+            .expect("Expected ConfigCache in global cache")
             .clone();
         let botinfo = botinfo_lock.read().await;
         botinfo.get("BOT_AVATAR").unwrap().clone()
@@ -75,9 +78,6 @@ pub async fn botinfo(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     debug!("Command executed");
     Ok(())
 }
-
-use crate::utls::constants::COLOR_OKAY;
-use std::process::Command;
 
 pub fn get_github_build(short: bool) -> String {
     // note: add error checking yourself.

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -6,7 +6,7 @@ use serenity::prelude::*;
 
 use wandbox::*;
 
-use crate::cache::{BotInfo, Stats, WandboxInfo};
+use crate::cache::{ConfigCache, WandboxCache, StatsManagerCache};
 use crate::utls::{discordhelpers, parser, parser::*};
 
 #[command]
@@ -19,8 +19,8 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     {
         let data_read = ctx.data.read().await;
         let botinfo_lock = data_read
-            .get::<BotInfo>()
-            .expect("Expected BotInfo in global cache")
+            .get::<ConfigCache>()
+            .expect("Expected ConfigCache in global cache")
             .clone();
         let botinfo = botinfo_lock.read().await;
         success_id = botinfo
@@ -52,7 +52,7 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
 
     // aquire lock to our wandbox cache
     let data_read = ctx.data.read().await;
-    let wandbox_lock = match data_read.get::<WandboxInfo>() {
+    let wandbox_lock = match data_read.get::<WandboxCache>() {
         Some(l) => l,
         None => {
             return Err(CommandError::from(
@@ -136,7 +136,7 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     compilation_embed.react(&ctx.http, reaction).await?;
 
     let data = ctx.data.read().await;
-    let stats = data.get::<Stats>().unwrap().lock().await;
+    let stats = data.get::<StatsManagerCache>().unwrap().lock().await;
     if stats.should_track() {
         stats.compilation(&builder.lang, result.status == "1").await;
     }

--- a/src/commands/compilers.rs
+++ b/src/commands/compilers.rs
@@ -4,7 +4,7 @@ use serenity::prelude::*;
 
 use serenity_utils::menu::*;
 
-use crate::cache::{BotInfo, WandboxInfo};
+use crate::cache::{WandboxCache, ConfigCache};
 use crate::utls::discordhelpers;
 
 #[command]
@@ -21,7 +21,7 @@ pub async fn compilers(ctx: &Context, msg: &Message, _args: Args) -> CommandResu
 
     // y lock on wandbox cache
     let data_read = ctx.data.read().await;
-    let wandbox_lock = match data_read.get::<WandboxInfo>() {
+    let wandbox_lock = match data_read.get::<WandboxCache>() {
         Some(l) => l,
         None => {
             return Err(CommandError::from("Internal request failure.\nWandbox cache is uninitialized, please file a bug if this error persists"));
@@ -46,7 +46,7 @@ pub async fn compilers(ctx: &Context, msg: &Message, _args: Args) -> CommandResu
     {
         let data_read = ctx.data.read().await;
         let botinfo_lock = data_read
-            .get::<BotInfo>()
+            .get::<ConfigCache>()
             .expect("Expected BotInfo in global cache")
             .clone();
         let botinfo = botinfo_lock.read().await;

--- a/src/commands/languages.rs
+++ b/src/commands/languages.rs
@@ -4,13 +4,13 @@ use serenity::prelude::*;
 
 use serenity_utils::menu::*;
 
-use crate::cache::{BotInfo, WandboxInfo};
+use crate::cache::{WandboxCache, ConfigCache};
 use crate::utls::discordhelpers;
 
 #[command]
 pub async fn languages(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     let data_read = ctx.data.read().await;
-    let wandbox_lock = match data_read.get::<WandboxInfo>() {
+    let wandbox_lock = match data_read.get::<WandboxCache>() {
         Some(l) => l,
         None => {
             return Err(CommandError::from(
@@ -32,7 +32,7 @@ pub async fn languages(ctx: &Context, msg: &Message, _args: Args) -> CommandResu
     {
         let data_read = ctx.data.read().await;
         let botinfo_lock = data_read
-            .get::<BotInfo>()
+            .get::<ConfigCache>()
             .expect("Expected BotInfo in global cache")
             .clone();
         let botinfo = botinfo_lock.read().await;

--- a/src/commands/unblock.rs
+++ b/src/commands/unblock.rs
@@ -2,7 +2,7 @@ use serenity::framework::standard::{macros::command, Args, CommandResult, Comman
 use serenity::model::prelude::*;
 use serenity::prelude::*;
 
-use crate::cache::BlockListInfo;
+use crate::cache::BlocklistCache;
 
 #[command]
 #[owners_only]
@@ -14,7 +14,7 @@ pub async fn unblock(ctx: &Context, msg: &Message, args: Args) -> CommandResult 
     let arg = args.parse::<u64>()?;
 
     let data = ctx.data.read().await;
-    let mut blocklist = data.get::<BlockListInfo>().unwrap().write().await;
+    let mut blocklist = data.get::<BlocklistCache>().unwrap().write().await;
 
     blocklist.unblock(arg);
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -93,8 +93,8 @@ impl EventHandler for Handler {
             }
 
             // update shard guild count & presence
-            let presence_str = format!("in {} servers | ;invite", sum);
-            ctx.set_presence(Some(Activity::playing(&presence_str)), OnlineStatus::Online).await;
+            let shard_manager = data.get::<ShardManagerInfo>().unwrap().lock().await;
+            discordhelpers::send_global_presence(&shard_manager, sum).await;
 
             info!("Joining {}", guild.name);
         }
@@ -135,10 +135,8 @@ impl EventHandler for Handler {
             }
         }
 
-        // update shard guild count & presence
-        let presence_str = format!("in {} servers | ;invite", sum);
-        ctx.set_presence(Some(Activity::playing(&presence_str)), OnlineStatus::Online).await;
-
+        let shard_manager = data.get::<ShardManagerInfo>().unwrap().lock().await;
+        discordhelpers::send_global_presence(&shard_manager, sum).await;
         info!("Leaving {}", &incomplete.id);
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -31,7 +31,7 @@ impl ShardsReadyHandler for Handler {
         let sum: u64 = shards.iter().sum();
 
         // update stats
-        let mut stats = data.get::<Stats>().unwrap().lock().await;
+        let mut stats = data.get::<StatsManagerCache>().unwrap().lock().await;
         if stats.should_track() {
             stats.post_servers(sum).await;
         }
@@ -53,7 +53,7 @@ impl EventHandler for Handler {
 
             // publish new server to stats
             {
-                let mut stats = data.get::<Stats>().unwrap().lock().await;
+                let mut stats = data.get::<StatsManagerCache>().unwrap().lock().await;
                 if stats.should_track() {
                     stats.new_server().await;
                 }
@@ -63,7 +63,7 @@ impl EventHandler for Handler {
             // post new server to join log
             let id;
             {
-                let info = data.get::<BotInfo>().unwrap().read().await;
+                let info = data.get::<ConfigCache>().unwrap().read().await;
                 id = info.get("BOT_ID").unwrap().parse::<u64>().unwrap();
 
                 if let Some(log) = info.get("JOIN_LOG") {
@@ -77,12 +77,12 @@ impl EventHandler for Handler {
             // update DBL site
             let sum : u64;
             {
-                let mut shard_info = data.get::<ShardServers>().unwrap().lock().await;
+                let mut shard_info = data.get::<ServerCountCache>().unwrap().lock().await;
                 let index = ctx.shard_id as usize;
                 shard_info[index] += 1;
                 sum = shard_info.iter().sum();
 
-                let dbl = data.get::<DBLApi>().unwrap().read().await;
+                let dbl = data.get::<DBLCache>().unwrap().read().await;
                 let new_stats = ShardStats::Shards {
                     shards: shard_info.clone(),
                 };
@@ -93,7 +93,7 @@ impl EventHandler for Handler {
             }
 
             // update shard guild count & presence
-            let shard_manager = data.get::<ShardManagerInfo>().unwrap().lock().await;
+            let shard_manager = data.get::<ShardManagerCache>().unwrap().lock().await;
             discordhelpers::send_global_presence(&shard_manager, sum).await;
 
             info!("Joining {}", guild.name);
@@ -102,13 +102,13 @@ impl EventHandler for Handler {
 
     async fn guild_delete(&self, ctx: Context, incomplete: GuildUnavailable) {
         let data = ctx.data.read().await;
-        let mut stats = data.get::<Stats>().unwrap().lock().await;
+        let mut stats = data.get::<StatsManagerCache>().unwrap().lock().await;
         if stats.should_track() {
             stats.leave_server().await;
         }
 
         // post new server to join log
-        let info = data.get::<BotInfo>().unwrap().read().await;
+        let info = data.get::<ConfigCache>().unwrap().read().await;
         let id = info.get("BOT_ID").unwrap().parse::<u64>().unwrap();
         if let Some(log) = info.get("JOIN_LOG") {
             if let Ok(id) = log.parse::<u64>() {
@@ -120,12 +120,12 @@ impl EventHandler for Handler {
         // update DBL site
         let sum : u64;
         {
-            let mut shard_info = data.get::<ShardServers>().unwrap().lock().await;
+            let mut shard_info = data.get::<ServerCountCache>().unwrap().lock().await;
             let index = ctx.shard_id as usize;
             shard_info[index] -= 1;
             sum = shard_info.iter().sum();
 
-            let dbl = data.get::<DBLApi>().unwrap().read().await;
+            let dbl = data.get::<DBLCache>().unwrap().read().await;
             let new_stats = ShardStats::Shards {
                 shards: shard_info.clone(),
             };
@@ -135,7 +135,7 @@ impl EventHandler for Handler {
             }
         }
 
-        let shard_manager = data.get::<ShardManagerInfo>().unwrap().lock().await;
+        let shard_manager = data.get::<ShardManagerCache>().unwrap().lock().await;
         discordhelpers::send_global_presence(&shard_manager, sum).await;
         info!("Leaving {}", &incomplete.id);
     }
@@ -143,10 +143,10 @@ impl EventHandler for Handler {
     async fn ready(&self, ctx: Context, ready: Ready) {
         info!("[Shard {}] Ready", ctx.shard_id);
         let data = ctx.data.read().await;
-        let mut info = data.get::<BotInfo>().unwrap().write().await;
+        let mut info = data.get::<ConfigCache>().unwrap().write().await;
         info.insert("BOT_AVATAR", ready.user.avatar_url().unwrap());
 
-        let mut shard_info = data.get::<ShardServers>().unwrap().lock().await;
+        let mut shard_info = data.get::<ServerCountCache>().unwrap().lock().await;
         shard_info.push(ready.guilds.len() as u64);
 
         if shard_info.len() == ready.shard.unwrap()[1] as usize {
@@ -163,7 +163,7 @@ impl EventHandler for Handler {
 pub async fn before(ctx: &Context, msg : &Message, _: &str) -> bool {
     let data = ctx.data.read().await;
     {
-        let stats = data.get::<Stats>().unwrap().lock().await;
+        let stats = data.get::<StatsManagerCache>().unwrap().lock().await;
         if stats.should_track() {
             stats.post_request().await;
         }
@@ -177,7 +177,7 @@ pub async fn before(ctx: &Context, msg : &Message, _: &str) -> bool {
 
     // check user against our blocklist
     {
-        let blocklist = data.get::<BlockListInfo>().unwrap().read().await;
+        let blocklist = data.get::<BlocklistCache>().unwrap().read().await;
         let author_blocklisted = blocklist.contains(msg.author.id.0);
         let guild_blocklisted = blocklist.contains(guild_id);
 
@@ -210,7 +210,7 @@ pub async fn after(
     command_name: &str,
     command_result: CommandResult,
 ) {
-    use crate::cache::Stats;
+    use crate::cache::StatsManagerCache;
     if let Err(e) = command_result {
         let emb = discordhelpers::build_fail_embed(&msg.author, &format!("{}", e));
         let mut emb_msg = discordhelpers::embed_message(emb);
@@ -225,7 +225,7 @@ pub async fn after(
     }
 
     let data = ctx.data.read().await;
-    let stats = data.get::<Stats>().unwrap().lock().await;
+    let stats = data.get::<StatsManagerCache>().unwrap().lock().await;
     if stats.should_track() {
         stats.command_executed(command_name).await;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .add_intent(GatewayIntents::GUILD_MESSAGE_REACTIONS)
         .await?;
 
-    cache::fill(client.data.clone(), &prefix, &bot_id).await?;
+    cache::fill(client.data.clone(), &prefix, &bot_id, client.shard_manager.clone()).await?;
 
     let dbl = BotsListAPI::new();
     if dbl.should_spawn() {

--- a/src/utls/discordhelpers.rs
+++ b/src/utls/discordhelpers.rs
@@ -12,6 +12,8 @@ use wandbox::*;
 
 use crate::utls::constants::*;
 use crate::utls::discordhelpers;
+use tokio::sync::MutexGuard;
+use serenity::client::bridge::gateway::{ShardManager};
 
 pub fn build_menu_items(
     items: Vec<String>,
@@ -327,6 +329,16 @@ pub fn build_complog_embed(
     embed.field("Code", format!("```{}\n{}\n```", lang, code), false);
 
     embed
+}
+
+pub async fn send_global_presence(shard_manager : &MutexGuard<'_, ShardManager>, sum : u64) {
+    // update shard guild count & presence
+    let presence_str = format!("in {} servers | ;invite", sum);
+
+    let runners = shard_manager.runners.lock().await;
+    for (_, v) in runners.iter() {
+        v.runner_tx.set_presence(Some(Activity::playing(&presence_str)), OnlineStatus::Online);
+    }
 }
 
 pub fn build_fail_embed(author: &User, err: &str) -> CreateEmbed {


### PR DESCRIPTION
Fixes #60 

This patch changes how the our presence is updated. Now, all presence changes are replicated across all shards to prevent any inaccuracies based off of which shard receives the latest event. These were always off-by-one errors, but it was annoying enough to bring this patch in.

I renamed cache elements to __Cache to ensure it's clear to understand exactly what's being accessed from where.

I'm also sneaking in other changes - we're now going to be grabbing git info at compile time, along with some additional documentation on cache stuffs.