### PR TITLE
Limit compilers menu to 15 items

### DIFF
--- a/src/commands/compilers.rs
+++ b/src/commands/compilers.rs
@@ -70,7 +70,7 @@ pub async fn compilers(ctx: &Context, msg: &Message, _args: Args) -> CommandResu
     let options = discordhelpers::build_menu_controls();
     let pages = discordhelpers::build_menu_items(
         items,
-        35,
+        15,
         "Supported Compilers",
         &avatar,
         &msg.author.tag(),


### PR DESCRIPTION
I'm not entirely sure how this menu was this large - but we're making it smaller now.

[Here](http://i.michaelwflaherty.com/u/hBKjvS0AQD.png)'s an example of the ridiculousness: 