### PR TITLE
Fix botinfo command regression

### DIFF
--- a/src/commands/botinfo.rs
+++ b/src/commands/botinfo.rs
@@ -14,9 +14,9 @@ pub async fn botinfo(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     let topgg = env::var("DISCORDBOTS_LINK").expect("Expected top.gg link envvar");
     let github = env::var("GITHUB_LINK").expect("Expected github link envvar");
     let stats = env::var("STATS_LINK").expect("Expected stats link envvar");
-    let hash_short = env::var("GIT_HASH_SHORT").expect("Expected stats link envvar");
-    let hash_long = env::var("GIT_HASH_LONG").expect("Expected stats link envvar");
 
+    let hash_short;
+    let hash_long;
     let avatar = {
         let data_read = ctx.data.read().await;
         let botinfo_lock = data_read
@@ -24,6 +24,8 @@ pub async fn botinfo(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
             .expect("Expected ConfigCache in global cache")
             .clone();
         let botinfo = botinfo_lock.read().await;
+        hash_short = botinfo.get("GIT_HASH_SHORT").unwrap().clone();
+        hash_long = botinfo.get("GIT_HASH_LONG").unwrap().clone();
         botinfo.get("BOT_AVATAR").unwrap().clone()
     };
 


### PR DESCRIPTION
This fixes a regression introduced by #67.

We were grabbing GIT_HASH_SHORT & GIT_HASH_LONG from the environment, but they actually exist as a part of our ConfigCache - uniquely separate from the rest of the members of ConfigCache.