### PR TITLE
Delete response on request deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "futures-util",
  "godbolt",
  "log",
+ "lru-cache",
  "pretty_env_logger",
  "regex",
  "reqwest",
@@ -739,12 +740,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ pretty_env_logger = "0.3"
 strip-ansi-escapes = "0.1.0"
 serde = { version = "1.0.*", features = ["derive"] }
 serde_json = "1.0"
+lru-cache = "0.1"
 
 #dbl
 dbl-rs = "0.2"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -69,7 +69,7 @@ impl TypeMapKey for ShardManagerCache {
     type Value = Arc<tokio::sync::Mutex<ShardManager>>;
 }
 
-/// Contains the shard manager - used to send global presence updates
+/// Message deletion cache to delete our own messages after the original request's deletion
 pub struct MessageDeleteCache;
 impl TypeMapKey for MessageDeleteCache {
     type Value = Arc<tokio::sync::Mutex<LruCache<u64, Message>>>;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,18 +1,22 @@
-use serenity::prelude::{TypeMap, TypeMapKey};
 use std::collections::HashMap;
 use std::env;
 use std::sync::Arc;
+use std::error::Error;
+
 use tokio::sync::RwLock;
+
+use serenity::prelude::{TypeMap, TypeMapKey};
+use serenity::futures::lock::Mutex;
+use serenity::model::id::UserId;
+use serenity::client::bridge::gateway::ShardManager;
 
 use crate::stats::statsmanager::StatsManager;
 use crate::utls::blocklist::Blocklist;
 
 use godbolt::Godbolt;
-use serenity::futures::lock::Mutex;
-use serenity::model::id::UserId;
-use std::error::Error;
 use wandbox::Wandbox;
-use serenity::client::bridge::gateway::ShardManager;
+use lru_cache::LruCache;
+use serenity::model::channel::Message;
 
 /** Caching **/
 
@@ -65,6 +69,12 @@ impl TypeMapKey for ShardManagerCache {
     type Value = Arc<tokio::sync::Mutex<ShardManager>>;
 }
 
+/// Contains the shard manager - used to send global presence updates
+pub struct MessageDeleteCache;
+impl TypeMapKey for MessageDeleteCache {
+    type Value = Arc<tokio::sync::Mutex<LruCache<u64, Message>>>;
+}
+
 pub async fn fill(
     data: Arc<RwLock<TypeMap>>,
     prefix: &str,
@@ -97,6 +107,9 @@ pub async fn fill(
     let wbox = wandbox::Wandbox::new(Some(broken_compilers), Some(broken_languages)).await?;
     info!("WandBox cache loaded");
     data.insert::<WandboxCache>(Arc::new(RwLock::new(wbox)));
+
+    // Message delete cache
+    data.insert::<MessageDeleteCache>(Arc::new(tokio::sync::Mutex::new(LruCache::new(10))));
 
     // Godbolt
     let godbolt = Godbolt::new().await?;

--- a/src/commands/asm.rs
+++ b/src/commands/asm.rs
@@ -7,7 +7,7 @@ use serenity_utils::menu::Menu;
 
 use godbolt::*;
 
-use crate::cache::{GodboltCache, ConfigCache};
+use crate::cache::{GodboltCache, ConfigCache, MessageDeleteCache};
 use crate::utls::constants::*;
 use crate::utls::parser::*;
 use crate::utls::{discordhelpers, parser};
@@ -114,6 +114,10 @@ pub async fn asm(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     }
 
     asm_embed.react(&ctx.http, reaction).await?;
+
+    let data_read = ctx.data.read().await;
+    let mut delete_cache = data_read.get::<MessageDeleteCache>().unwrap().lock().await;
+    delete_cache.insert(msg.id.0, asm_embed.clone());
     debug!("Command executed");
     Ok(())
 }

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -6,7 +6,7 @@ use serenity::prelude::*;
 
 use wandbox::*;
 
-use crate::cache::{ConfigCache, WandboxCache, StatsManagerCache};
+use crate::cache::{ConfigCache, WandboxCache, StatsManagerCache, MessageDeleteCache};
 use crate::utls::{discordhelpers, parser, parser::*};
 
 #[command]
@@ -158,6 +158,9 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
         }
     }
 
+    let data_read = ctx.data.read().await;
+    let mut delete_cache = data_read.get::<MessageDeleteCache>().unwrap().lock().await;
+    delete_cache.insert(msg.id.0, compilation_embed.clone());
     debug!("Command executed");
     Ok(())
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -105,7 +105,7 @@ impl EventHandler for Handler {
         let data = ctx.data.read().await;
         let mut delete_cache = data.get::<MessageDeleteCache>().unwrap().lock().await;
         if let Some(msg) = delete_cache.get_mut(id.as_u64()) {
-            if let Err(_) = msg.delete(ctx.http).await {
+            if msg.delete(ctx.http).await.is_err() {
                 // ignore for now
             }
             delete_cache.remove(id.as_u64());

--- a/src/events.rs
+++ b/src/events.rs
@@ -17,6 +17,7 @@ use crate::utls::discordhelpers;
 use chrono::{DateTime, Duration, Utc};
 use serenity::framework::standard::DispatchError;
 use dbl::types::ShardStats;
+use serenity::model::id::{ChannelId, MessageId};
 
 pub struct Handler; // event handler for serenity
 
@@ -97,6 +98,17 @@ impl EventHandler for Handler {
             discordhelpers::send_global_presence(&shard_manager, sum).await;
 
             info!("Joining {}", guild.name);
+        }
+    }
+
+    async fn message_delete(&self, ctx: Context, _channel_id: ChannelId, id: MessageId) {
+        let data = ctx.data.read().await;
+        let mut delete_cache = data.get::<MessageDeleteCache>().unwrap().lock().await;
+        if let Some(msg) = delete_cache.get_mut(id.as_u64()) {
+            if let Err(_) = msg.delete(ctx.http).await {
+                // ignore for now
+            }
+            delete_cache.remove(id.as_u64());
         }
     }
 


### PR DESCRIPTION
This has been sitting in the back of my head for quite some time - I quite like this feature.

When a user submits a request and then deletes their message, we'll also delete our response embed. Sometimes people make silly mistakes in their requests - and to prevent channel spam they delete their own message, with our message lingering behind.

This patch now prevents that.