### PR TITLE
Grab guild count from stats value

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -44,13 +44,6 @@ impl TypeMapKey for DBLCache {
     type Value = Arc<RwLock<dbl::Client>>;
 }
 
-/// Server count on boot, each shard has their own entry and server count
-//TODO: This should die eventually
-pub struct ServerCountCache;
-impl TypeMapKey for ServerCountCache {
-    type Value = Arc<Mutex<Vec<u64>>>;
-}
-
 /// Our endpoints for the in-house statistics tracing - see apis/dbl.rs
 pub struct StatsManagerCache;
 impl TypeMapKey for StatsManagerCache {
@@ -120,9 +113,6 @@ pub async fn fill(
     let token = env::var("DBL_TOKEN")?;
     let client = dbl::Client::new(token)?;
     data.insert::<DBLCache>(Arc::new(RwLock::new(client)));
-
-    // DBL
-    data.insert::<ServerCountCache>(Arc::new(Mutex::new(Vec::new())));
 
     // Stats tracking
     let stats = StatsManager::new();

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,45 +1,50 @@
 use serenity::{
     async_trait,
-    framework::{standard::macros::hook, standard::CommandResult},
+    framework::standard:: {
+        macros::hook, CommandResult, DispatchError
+    },
     model::{
         channel::Message,
         event::ResumedEvent,
         guild::{Guild, GuildUnavailable},
+        id::{ChannelId, MessageId},
+        gateway::Ready
     },
     prelude::*,
+    futures::lock::MutexGuard
 };
+
+use chrono::{DateTime, Duration, Utc};
 
 use crate::cache::*;
 use crate::utls::discordhelpers;
-use chrono::{DateTime, Duration, Utc};
-use serenity::framework::standard::DispatchError;
-use dbl::types::ShardStats;
-use serenity::model::id::{ChannelId, MessageId};
-use serenity::model::gateway::Ready;
+use crate::stats::statsmanager::StatsManager;
 
 pub struct Handler; // event handler for serenity
 
 #[async_trait]
 trait ShardsReadyHandler {
-    async fn all_shards_ready(&self, data: &TypeMap, shards: &[u64]);
+    async fn all_shards_ready(&self, ctx: &Context, stats: & mut MutexGuard<'_, StatsManager>, ready : &Ready);
 }
 
 #[async_trait]
 impl ShardsReadyHandler for Handler {
-    async fn all_shards_ready(&self, data: &TypeMap, shards: &[u64]) {
-        let sum: u64 = shards.iter().sum();
-
-        // update stats
-        let mut stats = data.get::<StatsManagerCache>().unwrap().lock().await;
-        if stats.should_track() {
-            stats.post_servers(sum).await;
-        }
+    async fn all_shards_ready(&self, ctx: &Context, stats: & mut MutexGuard<'_, StatsManager>, ready : &Ready) {
+        let data = ctx.data.read().await;
+        let mut info = data.get::<ConfigCache>().unwrap().write().await;
+        info.insert("BOT_AVATAR", ready.user.avatar_url().unwrap());
 
         let shard_manager = data.get::<ShardManagerCache>().unwrap().lock().await;
-        discordhelpers::send_global_presence(&shard_manager, sum).await;
+        let guild_count = stats.get_boot_vec_sum();
 
-        info!("{} shard(s) ready", shards.len());
-        debug!("Existing in {} guilds", sum);
+        // update stats
+        if stats.should_track() {
+            stats.post_servers(guild_count).await;
+        }
+
+        discordhelpers::send_global_presence(&shard_manager, guild_count).await;
+
+        info!("Ready in {} guilds", guild_count);
     }
 }
 
@@ -56,6 +61,7 @@ impl EventHandler for Handler {
                 stats.new_server().await;
             }
             let server_count = stats.server_count();
+            let shard_count = stats.shard_count();
 
 
             // post new server to join log
@@ -74,12 +80,11 @@ impl EventHandler for Handler {
 
             // update DBL site
             {
-                let shard_info = data.get::<ServerCountCache>().unwrap().lock().await;
                 let dbl = data.get::<DBLCache>().unwrap().read().await;
 
-                let new_stats = ShardStats::Cumulative {
+                let new_stats = dbl::types::ShardStats::Cumulative {
                     server_count,
-                    shard_count: Some(shard_info.len() as u64)
+                    shard_count: Some(shard_count)
                 };
 
                 if dbl.update_stats(id, new_stats).await.is_err() {
@@ -112,7 +117,6 @@ impl EventHandler for Handler {
         if stats.should_track() {
             stats.leave_server().await;
         }
-        let server_count = stats.server_count();
 
         // post new server to join log
         let info = data.get::<ConfigCache>().unwrap().read().await;
@@ -126,14 +130,12 @@ impl EventHandler for Handler {
 
         // update DBL site
         {
-            let shard_info = data.get::<ServerCountCache>().unwrap().lock().await;
-            let dbl = data.get::<DBLCache>().unwrap().read().await;
-
-            let new_stats = ShardStats::Cumulative {
-                server_count,
-                shard_count: Some(shard_info.len() as u64)
+            let new_stats = dbl::types::ShardStats::Cumulative {
+                server_count: stats.server_count(),
+                shard_count: Some(stats.shard_count())
             };
 
+            let dbl = data.get::<DBLCache>().unwrap().read().await;
             if dbl.update_stats(id, new_stats).await.is_err() {
                 warn!("Failed to post stats to dbl");
             }
@@ -141,22 +143,30 @@ impl EventHandler for Handler {
 
         // update shard guild count & presence
         let shard_manager = data.get::<ShardManagerCache>().unwrap().lock().await;
-        discordhelpers::send_global_presence(&shard_manager, server_count).await;
+        discordhelpers::send_global_presence(&shard_manager, stats.server_count()).await;
 
         info!("Leaving {}", &incomplete.id);
     }
 
     async fn ready(&self, ctx: Context, ready: Ready) {
         info!("[Shard {}] Ready", ctx.shard_id);
+
         let data = ctx.data.read().await;
-        let mut info = data.get::<ConfigCache>().unwrap().write().await;
-        info.insert("BOT_AVATAR", ready.user.avatar_url().unwrap());
+        let mut stats = data.get::<StatsManagerCache>().unwrap().lock().await;
 
-        let mut shard_info = data.get::<ServerCountCache>().unwrap().lock().await;
-        shard_info.push(ready.guilds.len() as u64);
+        // occasionally we can have a ready event fire well after execution
+        // this check prevents us from double calling all_shards_ready
+        let total_shards_to_spawn = ready.shard.unwrap()[1];
+        if stats.shard_count()+1 > total_shards_to_spawn {
+            info!("Skipping duplicate ready event...");
+            return;
+        }
 
-        if shard_info.len() == ready.shard.unwrap()[1] as usize {
-            self.all_shards_ready(&data, &shard_info).await;
+        let guild_count = ready.guilds.len() as u64;
+        stats.add_shard(guild_count);
+
+        if stats.shard_count() == total_shards_to_spawn {
+            self.all_shards_ready(&ctx, & mut stats, &ready).await;
         }
     }
 
@@ -216,7 +226,6 @@ pub async fn after(
     command_name: &str,
     command_result: CommandResult,
 ) {
-    use crate::cache::StatsManagerCache;
     if let Err(e) = command_result {
         let emb = discordhelpers::build_fail_embed(&msg.author, &format!("{}", e));
         let mut emb_msg = discordhelpers::embed_message(emb);

--- a/src/stats/statsmanager.rs
+++ b/src/stats/statsmanager.rs
@@ -58,6 +58,10 @@ impl StatsManager {
         self.send_request::<LegacyRequest>(&mut legacy).await;
     }
 
+    pub fn server_count(&self) -> u64 {
+        self.servers
+    }
+
     async fn send_request<T: Sendable + std::marker::Sync>(&self, sendable: &mut T) {
         sendable.set_key(&self.pass);
         match sendable.send(self.client.clone(), &self.url).await {

--- a/src/stats/statsmanager.rs
+++ b/src/stats/statsmanager.rs
@@ -9,6 +9,8 @@ pub struct StatsManager {
     url: String,
     pass: String,
     servers: u64,
+    shards: u64,
+    boot_count: Vec<u64>,
 }
 
 impl StatsManager {
@@ -18,6 +20,8 @@ impl StatsManager {
             url: env::var("STATS_API_LINK").unwrap_or_default(),
             pass: env::var("STATS_API_KEY").unwrap_or_default(),
             servers: 0,
+            shards: 0,
+            boot_count: Vec::new()
         }
     }
 
@@ -60,6 +64,19 @@ impl StatsManager {
 
     pub fn server_count(&self) -> u64 {
         self.servers
+    }
+
+    pub fn shard_count(&self) -> u64 {
+        self.shards
+    }
+
+    pub fn add_shard(& mut self, server_count : u64) {
+        self.shards += 1;
+        self.boot_count.push(server_count);
+    }
+
+    pub fn get_boot_vec_sum(&self) -> u64 {
+        self.boot_count.iter().sum()
     }
 
     async fn send_request<T: Sendable + std::marker::Sync>(&self, sendable: &mut T) {


### PR DESCRIPTION
Instead of relying on the `ServerCountCache`, we will now grab presence server count from the internal stats count held in `StatsManagerCache`.

This will also do away with `ServerCountCache` entirely - as any information about our statistics can be and should be held inside of our StatsManagerCache