### PR TITLE
Fix panic on no host

### DIFF
--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -116,9 +116,9 @@ pub async fn get_components(input: &str, author : &User) -> Result<ParserResult,
             return Err(ParserError::new("Unable to find host"))
         }
 
-        let host = url.host().unwrap().to_string();
-        if !URL_ALLOW_LIST.contains(&host.as_str()) {
-            warn!("Blocked URL request to: {} by {} [{}]", host, author.id.0, author.tag());
+        let host_str = host.unwrap().to_string();
+        if !URL_ALLOW_LIST.contains(&host_str.as_str()) {
+            warn!("Blocked URL request to: {} by {} [{}]", host_str, author.id.0, author.tag());
             return Err(ParserError::new("Unknown paste service. Please use pastebin.com, hastebin.com, or GitHub gists.\n\nAlso please be sure to use a 'raw text' link"))
         }
 

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -111,6 +111,11 @@ pub async fn get_components(input: &str, author : &User) -> Result<ParserResult,
             Ok(url) => url
         };
 
+        let host = url.host();
+        if host.is_none() {
+            return Err(ParserError::new("Unable to find host"))
+        }
+
         let host = url.host().unwrap().to_string();
         if !URL_ALLOW_LIST.contains(&host.as_str()) {
             warn!("Blocked URL request to: {} by {} [{}]", host, author.id.0, author.tag());


### PR DESCRIPTION
It's very possible to get no host when a user enters an invalid URI, and this case was not being handled properly. This patch adds a check for an invalid host and will refuse the request properly instead of panicking. 