### PR TITLE
Remove clippy & nightly builds from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,30 +16,30 @@ jobs:
       matrix:
         name:
           - ubuntu-latest-stable
-          - ubuntu-latest-nightly
+#          - ubuntu-latest-nightly
           - windows-latest-stable
-          - windows-latest-nightly
+#          - windows-latest-nightly
         include:
           - name: ubuntu-latest-stable
             os: ubuntu-latest
             rust: stable
             target: x86_64-unknown-linux-gnu
             rustflags: -D warnings
-          - name: ubuntu-latest-nightly
-            os: ubuntu-latest
-            rust: nightly
-            target: x86_64-unknown-linux-gnu
-            rustflags: -D warnings
+#          - name: ubuntu-latest-nightly
+#            os: ubuntu-latest
+#            rust: nightly
+#            target: x86_64-unknown-linux-gnu
+#            rustflags: -D warnings
           - name: windows-latest-stable
             os: windows-latest
             rust: stable
             target: x86_64-pc-windows-msvc
             rustflags: -D warnings
-          - name: windows-latest-nightly
-            os: windows-latest
-            rust: nightly
-            target: x86_64-pc-windows-msvc
-            rustflags: -D warnings
+ #         - name: windows-latest-nightly
+ #           os: windows-latest
+ #           rust: nightly
+ #           target: x86_64-pc-windows-msvc
+ #           rustflags: -D warnings
 
     steps:
       - uses: actions/checkout@v2
@@ -67,9 +67,9 @@ jobs:
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all --all-targets --target=${{ matrix.target }} -- -D warnings -p discord-compiler-bot
-        env:
-          RUSTFLAGS: ${{ matrix.rustflags }}
+#      - uses: actions-rs/cargo@v1
+#       with:
+#          command: clippy
+#          args: --all --all-targets --target=${{ matrix.target }} -- -D warnings -p discord-compiler-bot
+#        env:
+#          RUSTFLAGS: ${{ matrix.rustflags }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,6 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --all-targets --target=${{ matrix.target }} -- -D warnings
+          args: --all --all-targets --target=${{ matrix.target }} -- -D warnings -p discord-compiler-bot
         env:
           RUSTFLAGS: ${{ matrix.rustflags }}


### PR DESCRIPTION
~~This patch should prevent clippy from running on our dependencies which we have no control over.~~

This patch removes night builds and clippy from our CI. I'd love to have clippy running to look for bad patterns, but because we can't select it to analyze only our package, our dependencies are flagging us. Furthermore, nightly rust has issues that could also prevent CI from functioning as intended so we'll only test against stable compilations.