### PR TITLE
Include author id in complogs

### DIFF
--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -219,6 +219,7 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
                 &parse_result.code,
                 &builder.lang,
                 &msg.author.tag(),
+                msg.author.id.0,
                 &guild,
             );
             discordhelpers::manual_dispatch(ctx.http.clone(), id, emb).await;

--- a/src/utls/discordhelpers.rs
+++ b/src/utls/discordhelpers.rs
@@ -365,6 +365,7 @@ pub fn build_complog_embed(
     input_code: &str,
     lang: &str,
     tag: &str,
+    id: u64,
     guild: &str,
 ) -> CreateEmbed {
     let mut embed = CreateEmbed::default();
@@ -376,6 +377,7 @@ pub fn build_complog_embed(
     embed.title("Compilation requested");
     embed.field("Language", lang, true);
     embed.field("Author", tag, true);
+    embed.field("Author ID", id, true);
     embed.field("Guild", guild, true);
     let mut code = String::from(input_code);
     if code.len() > MAX_OUTPUT_LEN {


### PR DESCRIPTION
I'm not sure why this wasn't being logged beforehand, but this patch will also log the author's user id on compilation requests.

This makes it easier to block abusive users.