### PR TITLE
Allow language resolution via syntax highlighting

### DIFF
--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -40,17 +40,6 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
         loading_name = botinfo.get("LOADING_EMOJI_NAME").unwrap().clone();
     }
 
-    // parse user input
-    let parse_result: ParserResult = parser::get_components(&msg.content, &msg.author).await?;
-
-    // build user input
-    let mut builder = CompilationBuilder::new();
-    builder.code(&parse_result.code);
-    builder.target(&parse_result.target);
-    builder.stdin(&parse_result.stdin);
-    builder.save(true);
-    builder.options(parse_result.options);
-
     // aquire lock to our wandbox cache
     let data_read = ctx.data.read().await;
     let wandbox_lock = match data_read.get::<WandboxCache>() {
@@ -61,6 +50,18 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
             ));
         }
     };
+
+    // parse user input
+    let parse_result: ParserResult = parser::get_components(&msg.content, &msg.author, wandbox_lock).await?;
+
+    // build user input
+    let mut builder = CompilationBuilder::new();
+    builder.code(&parse_result.code);
+    builder.target(&parse_result.target);
+    builder.stdin(&parse_result.stdin);
+    builder.save(true);
+    builder.options(parse_result.options);
+
     let wbox = wandbox_lock.read().await;
 
     // build request


### PR DESCRIPTION
From what I've heard from our users, this is one of the most desired patches. This patch allows users to completely omit the language parameter after the `;compile` command *iff* the user supplies a supported language in discord's syntax highlighting embed.

An example of the new form is as follows:
``````
;compile -O3 -Wall -Werror
```c++
int main() {

}
```
``````

We will also maintain backwards compatibility for the old way. If the first argument after the `;compile` command resolves to a valid language or compiler, then we ignore the language parameter just as we used to.

Having been tested quite thoroughly already, this patch will live on the live bot for some time to ensure no issues arise before merge.