### PR TITLE
Include error messages in MessageDeleteCache

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -103,7 +103,7 @@ pub async fn fill(
     data.insert::<WandboxCache>(Arc::new(RwLock::new(wbox)));
 
     // Message delete cache
-    data.insert::<MessageDeleteCache>(Arc::new(tokio::sync::Mutex::new(LruCache::new(10))));
+    data.insert::<MessageDeleteCache>(Arc::new(tokio::sync::Mutex::new(LruCache::new(25))));
 
     // Godbolt
     let godbolt = Godbolt::new().await?;


### PR DESCRIPTION
This includes the deletion of malformed requests to the bot when the original request is deleted, just as successful requests behave.

We also will increase the size of the LruCache to 25, since that number seems large enough to represent the amount of requests we get.