### PR TITLE
Allow users to edit recent requests

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -62,9 +62,9 @@ impl TypeMapKey for ShardManagerCache {
     type Value = Arc<tokio::sync::Mutex<ShardManager>>;
 }
 
-/// Message deletion cache to delete our own messages after the original request's deletion
-pub struct MessageDeleteCache;
-impl TypeMapKey for MessageDeleteCache {
+/// Message  cache to interact with our own messages after they are dispatched
+pub struct MessageCache;
+impl TypeMapKey for MessageCache {
     type Value = Arc<tokio::sync::Mutex<LruCache<u64, Message>>>;
 }
 
@@ -103,7 +103,7 @@ pub async fn fill(
     data.insert::<WandboxCache>(Arc::new(RwLock::new(wbox)));
 
     // Message delete cache
-    data.insert::<MessageDeleteCache>(Arc::new(tokio::sync::Mutex::new(LruCache::new(25))));
+    data.insert::<MessageCache>(Arc::new(tokio::sync::Mutex::new(LruCache::new(25))));
 
     // Godbolt
     let godbolt = Godbolt::new().await?;

--- a/src/commands/asm.rs
+++ b/src/commands/asm.rs
@@ -7,7 +7,7 @@ use serenity_utils::menu::Menu;
 
 use godbolt::*;
 
-use crate::cache::{GodboltCache, ConfigCache, MessageDeleteCache};
+use crate::cache::{GodboltCache, ConfigCache, MessageCache};
 use crate::utls::constants::*;
 use crate::utls::parser::*;
 use crate::utls::{discordhelpers, parser};
@@ -116,8 +116,8 @@ pub async fn asm(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     asm_embed.react(&ctx.http, reaction).await?;
 
     let data_read = ctx.data.read().await;
-    let mut delete_cache = data_read.get::<MessageDeleteCache>().unwrap().lock().await;
-    delete_cache.insert(msg.id.0, asm_embed.clone());
+    let mut message_cache = data_read.get::<MessageCache>().unwrap().lock().await;
+    message_cache.insert(msg.id.0, asm_embed.clone());
     debug!("Command executed");
     Ok(())
 }

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -6,7 +6,7 @@ use serenity::prelude::*;
 
 use wandbox::*;
 
-use crate::cache::{ConfigCache, WandboxCache, StatsManagerCache, MessageDeleteCache};
+use crate::cache::{ConfigCache, WandboxCache, StatsManagerCache, MessageCache};
 use crate::utls::{discordhelpers, parser, parser::*};
 use serenity_utils::menu::Menu;
 
@@ -139,8 +139,8 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
                 // add message to delete cache
                 if let Some(m) = sent_msg {
                     let data_read = ctx.data.read().await;
-                    let mut delete_cache = data_read.get::<MessageDeleteCache>().unwrap().lock().await;
-                    delete_cache.insert(msg.id.0, m.clone());
+                    let mut message_cache = data_read.get::<MessageCache>().unwrap().lock().await;
+                    message_cache.insert(msg.id.0, m.clone());
 
                     let reaction;
                     if result.status == "0" {
@@ -197,8 +197,8 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
         }
         m.react(&ctx.http, reaction).await?;
         let data_read = ctx.data.read().await;
-        let mut delete_cache = data_read.get::<MessageDeleteCache>().unwrap().lock().await;
-        delete_cache.insert(msg.id.0, m);
+        let mut message_cache = data_read.get::<MessageCache>().unwrap().lock().await;
+        message_cache.insert(msg.id.0, m);
     }
 
 


### PR DESCRIPTION
Closes #95 

This patch allows users to edit their old requests and the bot will now rerun the code through wandbox or godbolt in order to prevent users from having to send multiple requests to get code to pass.

The implementation is quite crude and points at some underlying issues in regards to organization, where we now have some duplicated code. I'm intentionally adding technical debt here, but this debt will be paid back at a later date.