### PR TITLE
Add geordi-like cpp command

### DIFF
--- a/src/commands/cpp.rs
+++ b/src/commands/cpp.rs
@@ -9,9 +9,8 @@ use crate::cache::{WandboxCache, ConfigCache};
 use crate::utls::discordhelpers;
 
 #[command]
-#[owners_only]
+#[aliases("c++")]
 pub async fn cpp(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
-    let prefix;
     let loading_id;
     let loading_name;
     {
@@ -28,10 +27,18 @@ pub async fn cpp(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
             .parse::<u64>()
             .unwrap();
         loading_name = botinfo.get("LOADING_EMOJI_NAME").unwrap().clone();
-        prefix = botinfo.get("BOT_PREFIX").unwrap().clone();
     }
 
-    let mut eval = CppEval::new(&msg.content.replacen(&format!("{}cpp", prefix), "", 1));
+
+    let start = msg.content.find(' ');
+    if let None = start {
+        return Err(CommandError::from(
+            "Invalid usage. View `;help cpp`",
+        ));
+    }
+
+
+    let mut eval = CppEval::new(msg.content.split_at(start.unwrap()).1);
     let out = eval.evaluate();
 
     if let Err(e) = out {

--- a/src/commands/cpp.rs
+++ b/src/commands/cpp.rs
@@ -1,0 +1,125 @@
+use serenity::framework::standard::{macros::command, Args, CommandResult, CommandError};
+use serenity::model::prelude::*;
+use serenity::prelude::*;
+
+use crate::cppeval::eval::CppEval;
+
+use wandbox::CompilationBuilder;
+use crate::cache::{WandboxCache, ConfigCache};
+use crate::utls::discordhelpers;
+
+#[command]
+#[owners_only]
+pub async fn cpp(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
+    let prefix;
+    let loading_id;
+    let loading_name;
+    {
+        let data_read = ctx.data.read().await;
+        let botinfo_lock = data_read
+            .get::<ConfigCache>()
+            .expect("Expected ConfigCache in global cache")
+            .clone();
+        let botinfo = botinfo_lock.read().await;
+        loading_id = botinfo
+            .get("LOADING_EMOJI_ID")
+            .unwrap()
+            .clone()
+            .parse::<u64>()
+            .unwrap();
+        loading_name = botinfo.get("LOADING_EMOJI_NAME").unwrap().clone();
+        prefix = botinfo.get("BOT_PREFIX").unwrap().clone();
+    }
+
+    let mut eval = CppEval::new(&msg.content.replacen(&format!("{}cpp", prefix), "", 1));
+    let out = eval.evaluate();
+
+    if let Err(e) = out {
+        return Err(CommandError::from(
+            format!("{}", e),
+        ));
+    }
+
+    // send out loading emote
+    let reaction = match msg
+        .react(
+            &ctx.http,
+            discordhelpers::build_reaction(loading_id, &loading_name),
+        )
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            return Err(CommandError::from(format!(" Unable to react to message, am I missing permissions to react or use external emoji?\n{}", e)));
+        }
+    };
+
+    let output = out.unwrap();
+    //msg.channel_id.say(&ctx.http, format!("```\n{}\n```", &output)).await?;
+
+
+    let mut builder = CompilationBuilder::new();
+    builder.code(&output);
+    builder.target("gcc-10.1.0");
+    builder.stdin("");
+    builder.save(false);
+    builder.options(vec![String::from("-O2")]);
+
+    let data_read = ctx.data.read().await;
+    let wandbox_lock = match data_read.get::<WandboxCache>() {
+        Some(l) => l,
+        None => {
+            return Err(CommandError::from(
+                "Internal request failure\nWandbox cache is uninitialized, please file a bug.",
+            ));
+        }
+    };
+
+    let wbox = wandbox_lock.read().await;
+    // build request
+    match builder.build(&wbox) {
+        Ok(()) => (),
+        Err(e) => {
+            return Err(CommandError::from(format!(
+                "An internal error has occurred while building request.\n{}",
+                e
+            )));
+        }
+    };
+
+    let mut result = match builder.dispatch().await {
+        Ok(r) => r,
+        Err(e) => {
+            // we failed, lets remove the loading react so it doesn't seem like we're still processing
+            msg.delete_reaction_emoji(&ctx.http, reaction.emoji.clone())
+                .await?;
+
+            return Err(CommandError::from(format!("{}", e)));
+        }
+    };
+
+    // remove our loading emote
+    match msg
+        .delete_reaction_emoji(&ctx.http, reaction.emoji.clone())
+        .await
+    {
+        Ok(()) => (),
+        Err(_e) => {
+            return Err(CommandError::from(
+                "Unable to remove reactions!\nAm I missing permission to manage messages?",
+            ));
+        }
+    }
+
+    let emb = discordhelpers::build_small_compilation_embed(&msg.author, &mut result, 0);
+    let mut emb_msg = discordhelpers::embed_message(emb);
+
+    // Dispatch our request
+    let _ = msg
+        .channel_id
+        .send_message(&ctx.http, |_| &mut emb_msg)
+        .await?;
+
+    Ok(())
+}
+

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -53,8 +53,11 @@ pub async fn help(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
 
             "cpp" | "c++" => {
                 emb.title("c++/cpp command");
-                emb.field("Example 1", format!("{}cpp {{ int a = 4; if (a > 3) {{ cout << \"true\"}} }}", prefix), false);
-                emb.field("Example 1", format!("{}cpp {{ int a = 4; if (a > 3) {{ cout << \"true\"}} }}", prefix), false);
+                emb.field("Example 1", format!("{}cpp {{ int a = 4; if (a > 3) {{ cout << \"true\"; }} }}", prefix), false);
+                emb.field("Example 2", format!("{}cpp << (4*12) << \"Hello world!\"", prefix), false);
+                emb.field("Example 3", format!("{}cpp << f(2); int f(int a) {{ return a*12; }}", prefix), false);
+                emb.field("Example 4", format!("{}cpp int main() {{ cout << \"Main\"; f(); }} void f() {{ cout << \"f()\"; }}", prefix), false);
+                emb.field("Example 5", format!("*You may also use in-line code blocks if discord makes you escape some chars*\n{}cpp `<< (4*12) << \"\\\"Hello world!\\\"\"`", prefix), false);
                 "Allows you to quickly compile and execute c++ snippets using geordi-like syntax.\nSee section 2.1 of http://eel.is/geordi/#syntax"
             }
 
@@ -117,6 +120,7 @@ pub async fn help(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
             e.field("languages", "``` Displays all supported languages ```", false);
             e.field("asm", "```\nOutputs the assembly for the input code```", false);
             e.field("botinfo", "``` Displays information about the bot ```", false);
+            e.field("cpp", format!("``` Executes c++ code using geordi-like syntax\n See {}help cpp for more info ```", prefix), false);
             e
         })
     }).await?;

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -50,6 +50,14 @@ pub async fn help(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
                 emb.field("Example", format!("{}compilers <language>", prefix), false);
                 "Lists all compilers supported for a given language"
             }
+
+            "cpp" | "c++" => {
+                emb.title("c++/cpp command");
+                emb.field("Example 1", format!("{}cpp {{ int a = 4; if (a > 3) {{ cout << \"true\"}} }}", prefix), false);
+                emb.field("Example 1", format!("{}cpp {{ int a = 4; if (a > 3) {{ cout << \"true\"}} }}", prefix), false);
+                "Allows you to quickly compile and execute c++ snippets using geordi-like syntax.\nSee section 2.1 of http://eel.is/geordi/#syntax"
+            }
+
             "languages" => {
                 emb.title("Languages command");
                 emb.field("Example", format!("{}languages", prefix), false);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,3 +8,4 @@ pub mod ping;
 pub mod block;
 pub mod unblock;
 pub mod invite;
+pub mod cpp;

--- a/src/cppeval/eval.rs
+++ b/src/cppeval/eval.rs
@@ -1,0 +1,144 @@
+use core::fmt;
+
+#[derive(Debug, Clone)]
+pub struct EvalError {
+    details: String
+}
+impl EvalError {
+    fn new(msg: &str) -> EvalError {
+        EvalError{details: msg.to_string()}
+    }
+}
+impl fmt::Display for EvalError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f,"{}",self.details)
+    }
+}
+impl std::error::Error for EvalError {
+    fn description(&self) -> &str {
+        &self.details
+    }
+}
+
+pub struct CppEval {
+    input : String,
+    output : String
+}
+
+impl CppEval {
+    pub fn new(input : &String) -> CppEval {
+        CppEval {
+            input: input.trim().to_owned(),
+            output : String::default()
+        }
+    }
+
+    pub fn evaluate(& mut self) -> Result<String, EvalError> {
+        self.add_headers();
+
+        if self.input.starts_with("{") { // parsing a statement here
+            if let Err(e) = self.do_statements() {
+                return Err(e)
+            }
+        }
+        else if self.input.starts_with("<<") {
+            self.do_prints();
+        }
+        else { // they're handling their own main
+            if let Err(e) = self.do_user_handled() {
+                return Err(e)
+            }
+        }
+
+
+        Ok(self.output.clone())
+    }
+
+    pub fn do_user_handled(& mut self) -> Result<(), EvalError> {
+        let re = regex::Regex::new(r"(([a-zA-Z]*?)[\s]+main\((.*?)\)[\s]+\{[\s\S]*?\})").unwrap();
+
+        let mut found = false;
+        for capture in re.captures_iter(&self.input) {
+            let main = capture[1].trim().to_string();
+            let rest = self.input.replacen(&main, "", 1).trim().to_string();
+            println!("doing user handled");
+            self.output.push_str(&format!("{}\n", rest));
+            self.output.push_str(&format!("{}\n", main));
+
+            found = true;
+            break;
+        }
+
+        if !found {
+            return Err(EvalError::new("No main() specified. Invalid request"))
+        }
+
+
+        Ok(())
+    }
+
+    pub fn do_statements(& mut self) -> Result<(), EvalError>  {
+        let mut balance = 0;
+        let mut stop_idx = 0;
+        // TODO: prevent this from failing if people print '{' or '}'
+        for (index, char) in self.input.chars().enumerate() {
+            if char == '{' {
+                balance += 1;
+            }
+            if char == '}' {
+                balance -= 1;
+            }
+            if balance == 0 {
+                stop_idx = index;
+                break;
+            }
+        }
+
+        if stop_idx == 0 {
+            return Err(EvalError::new("Parsing failure, detected unbalanced curly-brackets."))
+        }
+
+        self.do_rest(stop_idx+1);
+
+        let statements = self.input[1..stop_idx].to_owned();
+        self.build_main(&statements);
+
+        Ok(())
+    }
+
+    pub fn do_rest(& mut self, start_idx : usize) {
+        let rest = &self.input[start_idx..];
+        self.output.push_str(rest.trim());
+    }
+
+    pub fn do_prints(& mut self) {
+        let input;
+        if let Some(statement_end) = self.input.find(';') {
+            self.do_rest(statement_end+1);
+
+            input = self.input[..statement_end].to_owned();
+        }
+        else {
+            input = self.input.clone();
+        }
+        self.build_main(&format!("cout {};", input));
+    }
+
+    pub fn add_headers(& mut self) {
+        self.output.push_str("#include <bits/stdc++.h>\n");
+        self.output.push_str("using namespace std;\n");
+        //self.add_ostreaming();
+    }
+
+    pub fn build_main(& mut self, statements : &String) {
+        self.output.push_str(&format!("\nint main (void) {{\n{}\n}}", statements));
+
+    }
+
+/*    pub fn add_ostreaming(& mut self) {
+        let vec_print = include_str!("more_ostreaming.in");
+        self.output.push_str(vec_print);
+        self.output.push_str("\n\n");
+    }
+*/
+}

--- a/src/cppeval/mod.rs
+++ b/src/cppeval/mod.rs
@@ -1,0 +1,1 @@
+pub mod eval;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod commands;
 mod events;
 mod stats;
 mod utls;
+mod cppeval;
 
 use serenity::{
     client::bridge::gateway::GatewayIntents,
@@ -25,11 +26,11 @@ extern crate pretty_env_logger;
 use crate::commands::{
     asm::ASM_COMMAND, botinfo::*, compile::*, compilers::*,
     help::*, languages::*, ping::*, block::*, unblock::*,
-    invite::*
+    invite::*, cpp::*
 };
 
 #[group]
-#[commands(botinfo, compile, languages, compilers, ping, help, asm, block, unblock, invite)]
+#[commands(botinfo, compile, languages, compilers, ping, help, asm, block, unblock, invite, cpp)]
 struct General;
 
 /** Spawn bot **/

--- a/src/utls/discordhelpers.rs
+++ b/src/utls/discordhelpers.rs
@@ -142,6 +142,31 @@ pub fn build_reaction(emoji_id: u64, emoji_name: &str) -> ReactionType {
     }
 }
 
+pub fn build_small_compilation_embed(author: &User, res: & mut CompilationResult, page_number : i32) -> CreateEmbed {
+    let mut embed = CreateEmbed::default();
+    if res.status != "0" {
+        embed.color(COLOR_FAIL);
+    } else {
+        embed.color(COLOR_OKAY);
+    }
+
+    if !res.compiler_all.is_empty() {
+        let str = conform_external_str(&res.compiler_all, 0, MAX_ERROR_LEN);
+        embed.field("Compiler Output", format!("```{}\n```", str), false);
+    }
+    if !res.program_all.is_empty() {
+        let str = conform_external_str(&res.program_all, page_number, MAX_OUTPUT_LEN);
+        embed.description(format!("```\n{}\n```", str));
+    }
+    embed.footer(|f| {
+        f.text(format!(
+            "Requested by: {} | Powered by wandbox.org",
+            author.tag()
+        ))
+    });
+
+    embed
+}
 pub fn build_compilation_embed(author: &User, res: & mut CompilationResult, page_number : i32) -> CreateEmbed {
     let mut embed = CreateEmbed::default();
 


### PR DESCRIPTION
This command creates some shorthand compilation alternatives for quick c++ evaluation. We're going to follow geordi's syntax as it will be familiar for those from IRC and it's quite simple overall. For more information regarding how this command works you can go to http://eel.is/geordi/#syntax

I'll be editing the website to show this command at some point in the future.

Closes #96 