### PR TITLE
Migrate to more of Compiler Explorer and less of WandBox

### DIFF
--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -13,7 +13,7 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     let data_read = ctx.data.read().await;
 
     // Handle wandbox request logic
-    let embed = crate::apis::wandbox::send_request(ctx.clone(), msg.content.clone(), msg.author.clone(), msg).await?;
+    let embed = crate::apis::wandbox::handle_request(ctx.clone(), msg.content.clone(), msg.author.clone(), msg).await?;
 
     // Send our final embed
     let mut message = embeds::embed_message(embed);

--- a/src/commands/compilers.rs
+++ b/src/commands/compilers.rs
@@ -4,7 +4,7 @@ use serenity::prelude::*;
 
 use serenity_utils::menu::*;
 
-use crate::cache::{WandboxCache, ConfigCache};
+use crate::cache::{ConfigCache, CompilerCache};
 use crate::utls::discordhelpers;
 use crate::utls::parser::shortname_to_qualified;
 
@@ -20,18 +20,14 @@ pub async fn compilers(ctx: &Context, msg: &Message, _args: Args) -> CommandResu
         }
     };
 
+
     // y lock on wandbox cache
     let data_read = ctx.data.read().await;
-    let wandbox_lock = match data_read.get::<WandboxCache>() {
-        Some(l) => l,
-        None => {
-            return Err(CommandError::from("Internal request failure.\nWandbox cache is uninitialized, please file a bug if this error persists"));
-        }
-    };
+    let compiler_cache = data_read.get::<CompilerCache>().unwrap();
+    let compiler_manager = compiler_cache.read().await;
 
     // Get our list of compilers
-    let wbox = wandbox_lock.read().await;
-    let lang = match wbox.get_compilers(&shortname_to_qualified(&language)) {
+    let lang = match compiler_manager.wbox.get_compilers(&shortname_to_qualified(&language)) {
         Some(s) => s,
         None => {
             return Err(CommandError::from(format!(

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -1,7 +1,7 @@
 use serenity::framework::standard::{macros::command, Args, CommandResult, CommandError, Delimiter};
 use serenity::model::prelude::*;
 use serenity::prelude::*;
-use crate::cache::GodboltCache;
+use crate::cache::{CompilerCache};
 use crate::utls::parser::{ParserResult, get_message_attachment};
 use godbolt::Godbolt;
 use std::io::Write;
@@ -31,7 +31,8 @@ pub async fn format(ctx: &Context, msg: &Message, mut args : Args) -> CommandRes
     }
 
     let data = ctx.data.read().await;
-    let gbolt = data.get::<GodboltCache>().unwrap().read().await;
+    let comp_mgr = data.get::<CompilerCache>().unwrap().read().await;
+    let gbolt = &comp_mgr.gbolt;
 
     // validate user input
     for format in &gbolt.formats {

--- a/src/commands/formats.rs
+++ b/src/commands/formats.rs
@@ -1,7 +1,7 @@
 use serenity::framework::standard::{macros::command, Args, CommandResult};
 use serenity::model::prelude::*;
 use serenity::prelude::*;
-use crate::cache::{GodboltCache, ConfigCache};
+use crate::cache::{ConfigCache, CompilerCache};
 use serenity::builder::CreateEmbed;
 
 use crate::utls::constants::{ICON_HELP, COLOR_OKAY};
@@ -10,7 +10,6 @@ use crate::utls::discordhelpers::embeds;
 #[command]
 pub async fn formats(ctx: &Context, msg: &Message, _args : Args) -> CommandResult {
     let data = ctx.data.read().await;
-    let gbolt = data.get::<GodboltCache>().unwrap().read().await;
     let prefix = {
         let botinfo_lock = data
             .get::<ConfigCache>()
@@ -20,12 +19,14 @@ pub async fn formats(ctx: &Context, msg: &Message, _args : Args) -> CommandResul
         botinfo.get("BOT_PREFIX").unwrap().clone()
     };
 
+    let compiler_manager = data.get::<CompilerCache>().unwrap().read().await;
+
     let mut emb = CreateEmbed::default();
     emb.thumbnail(ICON_HELP);
     emb.color(COLOR_OKAY);
     emb.title("Formatters:");
     emb.description(format!("Below is the list of all formatters currently supported, an valid example request can be `{}format rust`, or `{}format clang mozilla`", prefix, prefix));
-    for format in &gbolt.formats {
+    for format in &compiler_manager.gbolt.formats {
         let mut output = String::new();
         output.push_str("Styles:\n");
         if format.styles.is_empty() {

--- a/src/commands/languages.rs
+++ b/src/commands/languages.rs
@@ -4,24 +4,17 @@ use serenity::prelude::*;
 
 use serenity_utils::menu::*;
 
-use crate::cache::{WandboxCache, ConfigCache};
+use crate::cache::{ConfigCache, CompilerCache};
 use crate::utls::discordhelpers;
 
 #[command]
 pub async fn languages(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     let data_read = ctx.data.read().await;
-    let wandbox_lock = match data_read.get::<WandboxCache>() {
-        Some(l) => l,
-        None => {
-            return Err(CommandError::from(
-                "Internal request failure\nWandbox cache is uninitialized, please file a bug.",
-            ));
-        }
-    };
-    let wbox = wandbox_lock.read().await;
+    let compiler_cache = data_read.get::<CompilerCache>().unwrap();
+    let compiler_manager = compiler_cache.read().await;
 
     let mut items: Vec<String> = Vec::new();
-    let langs = wbox.get_languages();
+    let langs = compiler_manager.wbox.get_languages();
     for lang in langs {
         items.push(lang.name);
     }

--- a/src/utls/compilation_manager.rs
+++ b/src/utls/compilation_manager.rs
@@ -1,0 +1,138 @@
+use std::error::Error;
+
+use serenity::framework::standard::CommandError;
+use serenity::model::user::User;
+use serenity::builder::CreateEmbed;
+
+use wandbox::{Wandbox, CompilationBuilder, WandboxError};
+use godbolt::{Godbolt, GodboltError, CompilationFilters};
+
+use crate::utls::parser::ParserResult;
+use crate::utls::discordhelpers::embeds;
+use crate::utls::discordhelpers::embeds::ToEmbed;
+
+//Traits for compiler lookup
+pub trait LanguageResolvable {
+    fn resolve(&self, language : &str) -> bool;
+}
+
+impl LanguageResolvable for wandbox::Wandbox {
+    fn resolve(&self, language : &str) -> bool {
+        self.is_valid_language(language) || self.is_valid_compiler_str(language)
+    }
+}
+impl LanguageResolvable for godbolt::Godbolt {
+    fn resolve(&self, language : &str) -> bool {
+        self.resolve(language).is_some()
+    }
+}
+
+pub enum RequestHandler {
+    None,
+    WandBox,
+    CompilerExplorer
+}
+
+/// An abstraction for wandbox and godbolt. This object serves as the main interface between
+/// any api interactions and will control what languages use what service. Generally how this
+/// works is: if the language supported is owned by Compiler Explorer-, we will use them. Otherwise,
+/// we fallback on to WandBox to see if they can fulfill the request
+pub struct CompilationManager {
+    pub wbox : Wandbox,
+    pub gbolt : Godbolt
+}
+
+impl CompilationManager {
+    pub async fn new() -> Result<Self, Box<dyn Error>> {
+        let mut broken_compilers = std::collections::HashSet::new();
+        broken_compilers.insert(String::from("ghc-head"));
+        broken_compilers.insert(String::from("go-head"));
+        let mut broken_languages = std::collections::HashSet::new();
+        broken_languages.insert(String::from("cpp"));
+
+        Ok(CompilationManager {
+            wbox: wandbox::Wandbox::new(Some(broken_compilers), Some(broken_languages)).await?,
+            gbolt: Godbolt::new().await?
+        })
+    }
+
+    pub async fn compile(&self, parser_result : &ParserResult, author : &User) -> Result<(String, CreateEmbed), CommandError> {
+        match self.resolve_target(&parser_result.target) {
+            RequestHandler::CompilerExplorer => {
+                let result = self.compiler_explorer(parser_result).await?;
+                return Ok((result.0, result.1.to_embed(author, false)))
+            }
+            RequestHandler::WandBox => {
+                let mut result = self.wandbox(&parser_result).await?;
+                return Ok((result.0, embeds::build_compilation_embed(author, & mut result.1)))
+            }
+            RequestHandler::None => {
+                return Err(CommandError::from(
+                    format!("Unable to find compiler or language for target '{}'.", &parser_result.target),
+                ))
+            }
+        }
+    }
+
+    pub async fn assembly(&self, parse_result : &ParserResult, author : &User) -> Result<(String, CreateEmbed), CommandError> {
+        let filters = CompilationFilters {
+            binary: None,
+            comment_only: Some(true),
+            demangle: Some(true),
+            directives: Some(true),
+            execute: Some(false),
+            intel: Some(true),
+            labels: Some(true),
+            library_code: None,
+            trim: Some(true),
+        };
+
+        let compiler = self.gbolt.resolve(&parse_result.target).unwrap();
+        let response = Godbolt::send_request(&compiler, &parse_result.code, &parse_result.options.join(" "), &filters).await?;
+        Ok((compiler.lang, response.to_embed(author, true)))
+    }
+
+    pub async fn compiler_explorer(&self, parse_result : &ParserResult) -> Result<(String, godbolt::CompilationResult), GodboltError> {
+        let filters = CompilationFilters {
+            binary: None,
+            comment_only: Some(true),
+            demangle: Some(true),
+            directives: Some(true),
+            execute: Some(true),
+            intel: Some(true),
+            labels: Some(true),
+            library_code: None,
+            trim: Some(true),
+        };
+
+        let compiler = self.gbolt.resolve(&parse_result.target).unwrap();
+        let response = Godbolt::send_request(&compiler, &parse_result.code, &parse_result.options.join(" "), &filters).await?;
+        let compiler = self.gbolt.resolve(&parse_result.target).unwrap();
+        Ok((compiler.lang, response))
+    }
+
+    pub fn resolve_target(&self, target : &str) -> RequestHandler {
+        if self.gbolt.resolve(target).is_some() {
+            RequestHandler::CompilerExplorer
+        }
+        else if self.wbox.resolve(target) {
+            RequestHandler::WandBox
+        }
+        else {
+            RequestHandler::None
+        }
+    }
+
+    pub async fn wandbox(&self, parse_result : &ParserResult) -> Result<(String, wandbox::CompilationResult), WandboxError> {
+        let mut builder = CompilationBuilder::new();
+        builder.code(&parse_result.code);
+        builder.target(&parse_result.target);
+        builder.stdin(&parse_result.stdin);
+        builder.save(true);
+        builder.options(parse_result.options.clone());
+
+        builder.build(&self.wbox)?;
+        let res = builder.dispatch().await?;
+        Ok((builder.lang, res))
+    }
+}

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -148,7 +148,7 @@ pub async fn handle_edit_cpp(ctx : &Context, content : String, author : User, mu
 }
 
 pub async fn handle_edit_compile(ctx : &Context, content : String, author : User, mut old : Message) -> CommandResult {
-    let embed = crate::apis::wandbox::send_request(ctx.clone(), content, author, &old).await?;
+    let embed = crate::apis::wandbox::handle_request(ctx.clone(), content, author, &old).await?;
 
     let compilation_successful = embed.0.get("color").unwrap() == COLOR_OKAY;
     discordhelpers::send_completion_react(ctx, &old, compilation_successful).await?;
@@ -158,13 +158,17 @@ pub async fn handle_edit_compile(ctx : &Context, content : String, author : User
 }
 
 pub async fn handle_edit_asm(ctx : &Context, content : String, author : User, mut old : Message) -> CommandResult {
-    let emb = crate::apis::godbolt::send_request(ctx.clone(), content, author, &old).await?;
+    let emb = crate::apis::godbolt::handle_request(ctx.clone(), content, author, &old, true).await?;
 
     let success = emb.0.get("color").unwrap() == COLOR_OKAY;
     embeds::edit_message_embed(&ctx, & mut old, emb).await;
 
     send_completion_react(ctx, &old, success).await?;
     Ok(())
+}
+
+pub fn is_success_embed(embed : &CreateEmbed) -> bool {
+    embed.0.get("color").unwrap() == COLOR_OKAY
 }
 
 pub async fn send_completion_react(ctx: &Context, msg: &Message, success: bool) -> Result<Reaction, serenity::Error> {
@@ -192,7 +196,6 @@ pub async fn send_completion_react(ctx: &Context, msg: &Message, success: bool) 
         reaction = ReactionType::Unicode(String::from("❌"));
     }
     msg.react(&ctx.http, reaction).await
-
 }
 
 // Certain compiler outputs use unicode control characters that

--- a/src/utls/mod.rs
+++ b/src/utls/mod.rs
@@ -2,3 +2,4 @@ pub mod constants;
 pub mod discordhelpers;
 pub mod parser;
 pub mod blocklist;
+pub mod compilation_manager;

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -6,22 +6,8 @@ use serenity::framework::standard::CommandError;
 
 use tokio::sync::RwLock;
 use std::sync::Arc;
+use crate::utls::compilation_manager::{CompilationManager, RequestHandler};
 
-//Traits for compiler lookup
-pub trait LanguageResolvable {
-    fn resolve(&self, language : &str) -> bool;
-}
-
-impl LanguageResolvable for wandbox::Wandbox {
-    fn resolve(&self, language : &str) -> bool {
-        self.is_valid_language(language) || self.is_valid_compiler_str(language)
-    }
-}
-impl LanguageResolvable for godbolt::Godbolt {
-    fn resolve(&self, language : &str) -> bool {
-        self.resolve(language).is_some()
-    }
-}
 
 // Allows us to convert some common aliases to other programming languages
 pub fn shortname_to_qualified(language : &str) -> &str {
@@ -47,8 +33,7 @@ pub struct ParserResult {
 }
 
 #[allow(clippy::while_let_on_iterator)]
-pub async fn get_components<T : LanguageResolvable>(input: &str, author : &User, target_api : &Arc<RwLock<T>>, reply : &Option<Box<Message>>) -> Result<ParserResult, CommandError> {
-
+pub async fn get_components(input: &str, author : &User, compilation_manager : &Arc<RwLock<CompilationManager>>, reply : &Option<Box<Message>>) -> Result<ParserResult, CommandError> {
     let mut result = ParserResult::default();
 
     // we grab the index for the first code block - this will help us
@@ -68,11 +53,11 @@ pub async fn get_components<T : LanguageResolvable>(input: &str, author : &User,
     // Check to see if we were given a valid target... if not we'll check
     // the syntax highlighting str later.
     {
-        let lang_lookup = target_api.read().await;
+        let lang_lookup = compilation_manager.read().await;
         if let Some(param) = args.get(0) {
             let lower_param = param.trim().to_lowercase();
             let language = shortname_to_qualified(&lower_param);
-            if lang_lookup.resolve(&language) {
+            if !matches!(lang_lookup.resolve_target( language), RequestHandler::None) {
                 args.remove(0);
                 result.target = language.to_owned();
             }


### PR DESCRIPTION
As covered in #104, we're using a mixed approach where we primarily use Compiler Explorer. This will make WandBox easier to remove in the future and creates a formal interface between CE/WB and the bot as an organizational improvement.