### PR TITLE
Migrate Nim compilations back to Wandbox

### DIFF
--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -135,6 +135,9 @@ impl CompilationManager {
         if target == "scala" {
             return RequestHandler::WandBox
         }
+        else if parser_result.target == "nim" {
+            return RequestHandler::WandBox
+        }
 
         if self.gbolt.resolve(target).is_some() {
             RequestHandler::CompilerExplorer

--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -135,7 +135,7 @@ impl CompilationManager {
         if target == "scala" {
             return RequestHandler::WandBox
         }
-        else if parser_result.target == "nim" {
+        else if target == "nim" {
             return RequestHandler::WandBox
         }
 


### PR DESCRIPTION
Fixes #115 

Compiler Explorer will not handle execution requests for all of it's languages. This patch adds Nim to the list of languages we will only run on wandbox.