### PR TITLE
Balance multiline and inline comments

### DIFF
--- a/src/cppeval/eval.rs
+++ b/src/cppeval/eval.rs
@@ -97,11 +97,11 @@ impl CppEval {
         let mut balance = 0;
         let mut stop_idx = 0;
         let mut ignore = false;
+        let mut inline_comment = false;
+        let mut multiline_comment = false;
         let mut last = '\0';
         for (index, char) in self.input.chars().enumerate() {
-            // prevent }  in print statements from messing up our balance, we keep track of the
-            // last character parsed in order to detect escaped quotes that way we know which
-            // quotes indicate the start of a string and which ones do not.
+            // prevent non-syntactic }'s from messing up our balance
             if (char == '\'' || char == '"') && last != '\\' {
                 ignore = !ignore;
             }
@@ -109,6 +109,32 @@ impl CppEval {
                 last = char;
                 continue;
             }
+
+            if char == '/' && last == '/' {
+                inline_comment = true;
+            }
+
+            if inline_comment {
+                if char == '\n' {
+                    inline_comment = false;
+                }
+                last = char;
+                continue;
+            }
+
+            /* awd */
+            if char == '*' && last == '/' {
+                multiline_comment = true;
+            }
+
+            if multiline_comment {
+                if char == '/' && last == '*' {
+                    multiline_comment = false;
+                }
+                last = char;
+                continue;
+            }
+
             // balance our braces
             if char == '{' {
                 balance += 1;

--- a/src/tests/cpp.rs
+++ b/src/tests/cpp.rs
@@ -55,3 +55,18 @@ async fn eval_output_conditional() {
     let mut eval = CppEval::new("{ int a = 4; if (a > 3) { cout << \"true\"; } }");
     assert!(eval.evaluate().is_ok());
 }
+
+#[tokio::test]
+async fn eval_output_balance_inline() {
+    let mut eval = CppEval::new("{ // {{{{\n }");
+    assert!(eval.evaluate().is_ok());
+}
+
+#[tokio::test]
+async fn eval_output_balance() {
+    let mut eval = CppEval::new("{ /* {{{ */ }");
+    if let Err(e) = eval.evaluate() {
+        println!("{}", e);
+        assert!(false, "Parser failed")
+    }
+}


### PR DESCRIPTION
Fixes #108 

This patch expands bracket detection to ignore different comment styles.