### PR TITLE
Fix errors on one line parsing

### DIFF
--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -237,3 +237,48 @@ async fn standard_parse_late_deduce_compiler_block_stdin() {
     assert_eq!(parser_result.url, "");
     assert_eq!(parser_result.code, "console.log(\"beehee\");\n");
 }
+
+#[tokio::test]
+async fn standard_parse_one_line() {
+    let dummy_user = User::default();
+    let input = indoc::indoc!(
+        ";compile js ```console.log(\"beehee\");```"
+    );
+
+    let reply = None;
+    let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
+    let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
+    if let Err(_) = &result {
+        assert!(false, "Parser failed.");
+    }
+
+    let parser_result = result.unwrap();
+    assert_eq!(parser_result.target, "javascript");
+    assert_eq!(parser_result.args.len(), 0);
+    assert_eq!(parser_result.options.len(), 0);
+    assert_eq!(parser_result.stdin, "");
+    assert_eq!(parser_result.url, "");
+    assert_eq!(parser_result.code, "console.log(\"beehee\");");
+}
+
+#[tokio::test]
+async fn standard_parse_args_one_line() {
+    let dummy_user = User::default();
+    let input = indoc::indoc!(
+        ";compile c -O3```int main() {return 232;}```"
+    );
+
+    let reply = None;
+    let result = get_components(input, &dummy_user, None, &reply).await;
+    if let Err(_) = &result {
+        assert!(false, "Parser failed.");
+    }
+
+    let parser_result = result.unwrap();
+    assert_eq!(parser_result.target, "c");
+    assert_eq!(parser_result.args.len(), 0);
+    assert_eq!(parser_result.options, ["-O3"]);
+    assert_eq!(parser_result.stdin, "");
+    assert_eq!(parser_result.url, "");
+    assert_eq!(parser_result.code, "int main() {return 232;}");
+}

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -45,17 +45,18 @@ pub async fn get_components(input: &str, author : &User, compilation_manager : O
         end_point = parse_stop;
     }
     if let Some(index) = input.find('`') {
+        if end_point == 0 {
+            end_point = index;
+        }
         // if the ` character is found before \n we should use the ` as our parse stop point
-        if index < end_point {
+        else if index < end_point {
             end_point = index;
         }
     } else {
         end_point = input.len();
     }
 
-
     let mut args: Vec<&str> = input[..end_point].split_whitespace().collect();
-
     // ditch command str (;compile, ;asm)
     args.remove(0);
 


### PR DESCRIPTION
This error has been a little troublesome to find, but we've got it.

For requests in the form
``````
.compile c -O3```int main() { }```
``````

We'd not find a new line character and the ` *was* found. Previous logic would fail to update the codeblock start position and we'd eventually end up removing from an empty array.