### PR TITLE
Add error on .env not found & allow no dbl token

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -100,9 +100,10 @@ pub async fn fill(
     info!("Compilation manager loaded");
 
     // DBL
-    let token = env::var("DBL_TOKEN")?;
-    let client = dbl::Client::new(token)?;
-    data.insert::<DblCache>(Arc::new(RwLock::new(client)));
+    if let Ok(token) = env::var("DBL_TOKEN") {
+        let client = dbl::Client::new(token)?;
+        data.insert::<DblCache>(Arc::new(RwLock::new(client)));
+    }
 
     // Stats tracking
     let stats = StatsManager::new();

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -89,7 +89,7 @@ pub async fn handle_request(ctx : Context, mut content : String, author : User, 
             return Err(CommandError::from(format!("{}", e)));
         }
     };
-
+    
     // remove our loading emote
     if msg.delete_reaction_emoji(&ctx.http, reaction.emoji.clone()).await
         .is_err()

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,10 @@ struct General;
 /** Spawn bot **/
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    dotenv::dotenv().ok();
+    if let Err(e) = dotenv::dotenv() {
+        error!("Unable to find .env configuration file: {}", e);
+    }
+
     pretty_env_logger::init();
 
     let token = env::var("BOT_TOKEN")?;


### PR DESCRIPTION
This should make the bot easier to self host, I'm not sure why dbl token was required prior to this patch but I believe it's no longer needed.