### PR TITLE
Temporarily patch Haskell & ignore casing on compilers lookup

### DIFF
--- a/src/commands/compilers.rs
+++ b/src/commands/compilers.rs
@@ -28,7 +28,8 @@ pub async fn compilers(ctx: &Context, msg: &Message, _args: Args) -> CommandResu
     // Get our list of compilers
     let mut langs: Vec<String> = Vec::new();
 
-    let language = shortname_to_qualified(&user_lang.to_lowercase());
+    let lower_lang = user_lang.to_lowercase();
+    let language = shortname_to_qualified(&lower_lang);
     match compiler_manager.resolve_target(language) {
         RequestHandler::CompilerExplorer => {
             for cache_entry in &compiler_manager.gbolt.cache {

--- a/src/commands/compilers.rs
+++ b/src/commands/compilers.rs
@@ -28,7 +28,7 @@ pub async fn compilers(ctx: &Context, msg: &Message, _args: Args) -> CommandResu
     // Get our list of compilers
     let mut langs: Vec<String> = Vec::new();
 
-    let language = shortname_to_qualified(&user_lang);
+    let language = shortname_to_qualified(&user_lang.to_lowercase());
     match compiler_manager.resolve_target(language) {
         RequestHandler::CompilerExplorer => {
             for cache_entry in &compiler_manager.gbolt.cache {

--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -96,7 +96,10 @@ impl CompilationManager {
             execute_parameters: Default::default(),
             filters
         };
-        let compiler = self.gbolt.resolve(&parse_result.target).unwrap();
+
+        let target = if parse_result.target == "haskell" { "ghc901" } else { &parse_result.target };
+
+        let compiler = self.gbolt.resolve(target).unwrap();
         let response = Godbolt::send_request(&compiler, &parse_result.code, options, USER_AGENT).await?;
         Ok((compiler.lang, response.to_embed(author, true)))
     }

--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -98,7 +98,6 @@ impl CompilationManager {
         };
 
         let target = if parse_result.target == "haskell" { "ghc901" } else { &parse_result.target };
-
         let compiler = self.gbolt.resolve(target).unwrap();
         let response = Godbolt::send_request(&compiler, &parse_result.code, options, USER_AGENT).await?;
         Ok((compiler.lang, response.to_embed(author, true)))
@@ -129,7 +128,9 @@ impl CompilationManager {
             },
             filters
         };
-        let compiler = self.gbolt.resolve(&parse_result.target).unwrap();
+
+        let target = if parse_result.target == "haskell" { "ghc901" } else { &parse_result.target };
+        let compiler = self.gbolt.resolve(target).unwrap();
         let response = Godbolt::send_request(&compiler, &parse_result.code,  options, USER_AGENT).await?;
         Ok((compiler.lang, response))
     }


### PR DESCRIPTION
Haskell currently defaults to a version of the compiler which requires a dependency Compiler Explorer does not have, this is an issue with the Haskell compiler. Ref: https://github.com/compiler-explorer/compiler-explorer/issues/3418

We'll just hack around this for now.