### PR TITLE
Correctly identify original message replys for edits

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -55,10 +55,24 @@ impl TypeMapKey for ShardManagerCache {
     type Value = Arc<Mutex<ShardManager>>;
 }
 
+pub struct MessageCacheEntry {
+    pub our_msg : Message,
+    pub original_msg : Message
+}
+impl MessageCacheEntry {
+    pub fn new(our_msg : Message, original_msg : Message) -> Self {
+        MessageCacheEntry {
+            our_msg,
+            original_msg
+        }
+    }
+}
+
+
 /// Message  cache to interact with our own messages after they are dispatched
 pub struct MessageCache;
 impl TypeMapKey for MessageCache {
-    type Value = Arc<Mutex<LruCache<u64, Message>>>;
+    type Value = Arc<Mutex<LruCache<u64, MessageCacheEntry>>>;
 }
 
 pub async fn fill(

--- a/src/commands/asm.rs
+++ b/src/commands/asm.rs
@@ -3,7 +3,7 @@ use serenity::{
     framework::standard::{macros::command, Args, CommandError, CommandResult},
 };
 
-use crate::cache::{ConfigCache, MessageCache, CompilerCache};
+use crate::cache::{ConfigCache, MessageCache, CompilerCache, MessageCacheEntry};
 use crate::utls::constants::*;
 use crate::utls::{discordhelpers};
 use crate::utls::discordhelpers::embeds;
@@ -30,7 +30,7 @@ pub async fn asm(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
 
     let data_read = ctx.data.read().await;
     let mut message_cache = data_read.get::<MessageCache>().unwrap().lock().await;
-    message_cache.insert(msg.id.0, asm_embed.clone());
+    message_cache.insert(msg.id.0, MessageCacheEntry::new(asm_embed.clone(), msg.clone()));
     debug!("Command executed");
     Ok(())
 }

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -1,6 +1,6 @@
 use serenity::framework::standard::{macros::command, Args, CommandResult};
 
-use crate::cache::{MessageCache};
+use crate::cache::{MessageCache, MessageCacheEntry};
 use crate::utls::{parser, discordhelpers};
 use crate::utls::constants::COLOR_OKAY;
 use crate::utls::discordhelpers::{embeds, is_success_embed};
@@ -37,7 +37,7 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     discordhelpers::send_completion_react(ctx, &compilation_embed, compilation_successful).await?;
 
     let mut delete_cache = data_read.get::<MessageCache>().unwrap().lock().await;
-    delete_cache.insert(msg.id.0, compilation_embed);
+    delete_cache.insert(msg.id.0, MessageCacheEntry::new(compilation_embed, msg.clone()));
     debug!("Command executed");
     Ok(())
 }

--- a/src/commands/cpp.rs
+++ b/src/commands/cpp.rs
@@ -2,7 +2,7 @@ use serenity::framework::standard::{macros::command, Args, CommandResult, Comman
 use serenity::model::prelude::*;
 use serenity::prelude::*;
 
-use crate::cache::{MessageCache, CompilerCache, ConfigCache};
+use crate::cache::{MessageCache, CompilerCache, ConfigCache, MessageCacheEntry};
 use crate::utls::discordhelpers::embeds;
 use crate::utls::discordhelpers;
 use crate::cppeval::eval::CppEval;
@@ -26,7 +26,7 @@ pub async fn cpp(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     // add delete cache
     let data_read = ctx.data.read().await;
     let mut delete_cache = data_read.get::<MessageCache>().unwrap().lock().await;
-    delete_cache.insert(msg.id.0, compilation_embed);
+    delete_cache.insert(msg.id.0, MessageCacheEntry::new(compilation_embed, msg.clone()));
 
     Ok(())
 }

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -104,7 +104,7 @@ pub fn build_reaction(emoji_id: u64, emoji_name: &str) -> ReactionType {
     }
 }
 
-pub async fn handle_edit(ctx : &Context, content : String, author : User, mut old : Message) {
+pub async fn handle_edit(ctx : &Context, content : String, author : User, mut old : Message, original_message: Message) {
     let prefix = {
         let data = ctx.data.read().await;
         let info = data.get::<ConfigCache>().unwrap().read().await;
@@ -115,19 +115,19 @@ pub async fn handle_edit(ctx : &Context, content : String, author : User, mut ol
     let _ = old.delete_reactions(&ctx).await;
 
     if content.starts_with(&format!("{}asm", prefix)) {
-        if let Err(e) = handle_edit_asm(&ctx, content, author.clone(), old.clone()).await {
+        if let Err(e) = handle_edit_asm(&ctx, content, author.clone(), old.clone(), original_message.clone()).await {
             let err = embeds::build_fail_embed(&author, &e.to_string());
             embeds::edit_message_embed(&ctx, & mut old, err).await;
         }
     }
     else if content.starts_with(&format!("{}compile", prefix)) {
-        if let Err(e) = handle_edit_compile(&ctx, content, author.clone(), old.clone()).await {
+        if let Err(e) = handle_edit_compile(&ctx, content, author.clone(), old.clone(), original_message.clone()).await {
             let err = embeds::build_fail_embed(&author, &e.to_string());
             embeds::edit_message_embed(&ctx, & mut old, err).await;
         }
     }
     else if content.starts_with(&format!("{}cpp", prefix)) {
-        if let Err(e) = handle_edit_cpp(&ctx, content, author.clone(), old.clone()).await {
+        if let Err(e) = handle_edit_cpp(&ctx, content, author.clone(), old.clone(), original_message.clone()).await {
             let err = embeds::build_fail_embed(&author, &e.to_string());
             embeds::edit_message_embed(&ctx, & mut old, err).await;
         }
@@ -138,8 +138,8 @@ pub async fn handle_edit(ctx : &Context, content : String, author : User, mut ol
     }
 }
 
-pub async fn handle_edit_cpp(ctx : &Context, content : String, author : User, mut old : Message) -> CommandResult {
-    let embed = crate::commands::cpp::handle_request(ctx.clone(), content, author, &old).await?;
+pub async fn handle_edit_cpp(ctx : &Context, content : String, author : User, mut old : Message, original_msg: Message) -> CommandResult {
+    let embed = crate::commands::cpp::handle_request(ctx.clone(), content, author, &original_msg).await?;
 
     let compilation_successful = embed.0.get("color").unwrap() == COLOR_OKAY;
     discordhelpers::send_completion_react(ctx, &old, compilation_successful).await?;
@@ -148,8 +148,8 @@ pub async fn handle_edit_cpp(ctx : &Context, content : String, author : User, mu
     Ok(())
 }
 
-pub async fn handle_edit_compile(ctx : &Context, content : String, author : User, mut old : Message) -> CommandResult {
-    let embed = crate::commands::compile::handle_request(ctx.clone(), content, author, &old).await?;
+pub async fn handle_edit_compile(ctx : &Context, content : String, author : User, mut old : Message, original_msg: Message) -> CommandResult {
+    let embed = crate::commands::compile::handle_request(ctx.clone(), content, author, &original_msg).await?;
 
     let compilation_successful = embed.0.get("color").unwrap() == COLOR_OKAY;
     discordhelpers::send_completion_react(ctx, &old, compilation_successful).await?;
@@ -158,8 +158,8 @@ pub async fn handle_edit_compile(ctx : &Context, content : String, author : User
     Ok(())
 }
 
-pub async fn handle_edit_asm(ctx : &Context, content : String, author : User, mut old : Message) -> CommandResult {
-    let emb = crate::commands::asm::handle_request(ctx.clone(), content, author, &old).await?;
+pub async fn handle_edit_asm(ctx : &Context, content : String, author : User, mut old : Message, original_msg: Message) -> CommandResult {
+    let emb = crate::commands::asm::handle_request(ctx.clone(), content, author, &original_msg).await?;
 
     let success = emb.0.get("color").unwrap() == COLOR_OKAY;
     embeds::edit_message_embed(&ctx, & mut old, emb).await;


### PR DESCRIPTION
Fixes #130

This patch adds the original message sent into our message cache so we can correctly identify message replys