### PR TITLE
Fix unwrap on None value for invalid assembly target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ version = "0.1"
 
 [dependencies.godbolt]
 git = "https://github.com/Headline/godbolt-rs"
-branch = "breaking-change"
+branch = "master"
 #path = '../godbolt-rs'
 
 [dependencies.serenity_utils]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -88,7 +88,7 @@ pub async fn fill(
 
     // optional additions
     let emoji_identifiers = ["SUCCESS_EMOJI_ID", "SUCCESS_EMOJI_NAME", "LOADING_EMOJI_ID", "LOADING_EMOJI_NAME", "LOGO_EMOJI_NAME", "LOGO_EMOJI_ID"];
-    for id in emoji_identifiers{
+    for id in &emoji_identifiers{
         if let Ok(envvar) = env::var(id) {
             if !envvar.is_empty() {
                 map.insert(id, envvar);


### PR DESCRIPTION
Fixes #121 

This patch fixes a minor bug when trying to view assembly output for languages or compiler which are not supported for this feature.

Continue to refer to `;languages` for this support.