### PR TITLE
Support include urls

### DIFF
--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -60,7 +60,7 @@ pub async fn format(ctx: &Context, msg: &Message, mut args : Args) -> CommandRes
 
     if let Some(msgref) = &msg.referenced_message {
         let mut result = ParserResult::default();
-        if crate::utls::parser::find_code_block(& mut result, &msgref.content) {
+        if crate::utls::parser::find_code_block(& mut result, &msgref.content, &msg.author).await? {
             lang_code = result.target.clone();
             code = result.code
         }
@@ -82,7 +82,7 @@ pub async fn format(ctx: &Context, msg: &Message, mut args : Args) -> CommandRes
             code = program_code;
         } else {
             let mut result = ParserResult::default();
-            if crate::utls::parser::find_code_block(& mut result, &msg.content) {
+            if crate::utls::parser::find_code_block(& mut result, &msg.content, &msg.author).await? {
                 lang_code = result.target.clone();
                 code = result.code
             }

--- a/src/slashcmds/format.rs
+++ b/src/slashcmds/format.rs
@@ -22,7 +22,7 @@ pub async fn format(ctx: &Context, command: &ApplicationCommandInteraction) -> C
     let mut parse_result = ParserResult::default();
 
     for (_, value) in &command.data.resolved.messages {
-        if !parser::find_code_block(& mut parse_result, &value.content) {
+        if !parser::find_code_block(& mut parse_result, &value.content, &command.user).await? {
             return Err(CommandError::from("Unable to find a codeblock to format!"))
         }
         msg = Some(value);

--- a/src/utls/discordhelpers/interactions.rs
+++ b/src/utls/discordhelpers/interactions.rs
@@ -272,7 +272,7 @@ where
 
     let mut msg = None;
     for (_, value) in &command.data.resolved.messages {
-        if !parser::find_code_block(& mut parse_result, &value.content) {
+        if !parser::find_code_block(& mut parse_result, &value.content, &command.user).await? {
             command.create_interaction_response(&ctx.http, |resp| {
                 resp.kind(InteractionResponseType::DeferredChannelMessageWithSource)
                     .interaction_response_data(|data| {


### PR DESCRIPTION
Closes #129 

This brings in the popular compiler explorer feature that allows folks to include header files into their code compilations by inserting a url instead of a path.