### PR TITLE
Allow server count presence to show when stats are disabled

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -50,10 +50,7 @@ impl ShardsReadyHandler for Handler {
         let shard_manager = data.get::<ShardManagerCache>().unwrap().lock().await;
         let guild_count = stats.get_boot_vec_sum();
 
-        // update stats
-        if stats.should_track() {
-            stats.post_servers(guild_count).await;
-        }
+        stats.post_servers(guild_count).await;
 
         discordhelpers::send_global_presence(&shard_manager, stats.server_count()).await;
 
@@ -84,9 +81,7 @@ impl EventHandler for Handler {
 
             // publish/queue new server to stats
             let mut stats = data.get::<StatsManagerCache>().unwrap().lock().await;
-            if stats.should_track() {
-                stats.new_server().await;
-            }
+            stats.new_server().await;
 
             // ensure we're actually loaded in before we start posting our server counts
             if stats.server_count() > 0
@@ -138,9 +133,7 @@ impl EventHandler for Handler {
 
         // publish/queue new server to stats
         let mut stats = data.get::<StatsManagerCache>().unwrap().lock().await;
-        if stats.should_track() {
-            stats.leave_server().await;
-        }
+        stats.leave_server().await;
 
         // ensure we're actually loaded in before we start posting our server counts
         if stats.server_count() > 0

--- a/src/managers/stats.rs
+++ b/src/managers/stats.rs
@@ -60,8 +60,10 @@ impl StatsManager {
         self.leave_queue = 0;
 
         // update our stats
-        let mut legacy = LegacyRequest::new(Some(self.servers));
-        self.send_request::<LegacyRequest>(&mut legacy).await;
+        if self.should_track() {
+            let mut legacy = LegacyRequest::new(Some(self.servers));
+            self.send_request::<LegacyRequest>(&mut legacy).await;
+        }
     }
 
     pub async fn new_server(&mut self) {
@@ -71,8 +73,10 @@ impl StatsManager {
         }
 
         self.servers += 1;
-        let mut legacy = LegacyRequest::new(Some(self.servers));
-        self.send_request::<LegacyRequest>(&mut legacy).await;
+        if self.should_track() {
+            let mut legacy = LegacyRequest::new(Some(self.servers));
+            self.send_request::<LegacyRequest>(&mut legacy).await;
+        }
     }
 
     pub async fn leave_server(&mut self) {
@@ -82,8 +86,10 @@ impl StatsManager {
         }
 
         self.servers -= 1;
-        let mut legacy = LegacyRequest::new(Some(self.servers));
-        self.send_request::<LegacyRequest>(&mut legacy).await;
+        if self.should_track() {
+            let mut legacy = LegacyRequest::new(Some(self.servers));
+            self.send_request::<LegacyRequest>(&mut legacy).await;
+        }
     }
 
     pub async fn post_request(&self) {


### PR DESCRIPTION
The server count available in the Bot's presence is 0 when statistics tracking is not enabled. This patch changes our tracking strategy to also consider guild counts even when statistics aren't being posted.