### PR TITLE
Remove necessity for manage messages permission

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ RUST_LOG=discord_compiler_bot
 BOT_PREFIX=;
 
 ## Bot info links
-INVITE_LINK=https://discordapp.com/oauth2/authorize?client_id=504095380166803466&scope=bot&permissions=388160
+INVITE_LINK=https://discordapp.com/oauth2/authorize?client_id=504095380166803466&scope=bot&permissions=379968
 DISCORDBOTS_LINK=https://discordbots.org/bot/504095380166803466
 GITHUB_LINK=https://github.com/Headline/discord-compiler
 STATS_LINK=http://headlinedev.xyz/discord-compiler

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@
 ## Bot login token
 BOT_TOKEN=
 
+## Bot's application ID
+APPLICATION_ID=
+
 ## Show only our logs, serenity is noisy
 RUST_LOG=discord_compiler_bot
 
@@ -16,6 +19,11 @@ GITHUB_LINK=https://github.com/Headline/discord-compiler
 STATS_LINK=http://headlinedev.xyz/discord-compiler
 
 # Optional variables
+
+## If the bot is unable to fetch it's own application info, having this filled in will allow
+## the bot to continue
+BOT_ID=
+
 ## Emojis
 SUCCESS_EMOJI_NAME=
 SUCCESS_EMOJI_ID=
@@ -24,12 +32,16 @@ LOADING_EMOJI_ID=
 LOGO_EMOJI_NAME=
 LOGO_EMOJI_ID=
 
-BOT_ID=
+## Usage logging
 COMPILE_LOG=
 JOIN_LOG=
+
+## Top.gg bot voting announcement
 VOTE_CHANNEL=
 DBL_TOKEN=
 DBL_WEBHOOK_PORT=
 DBL_WEBHOOK_PASSWORD=
+
+## Statistics tracking API
 STATS_API_LINK=
 STATS_API_KEY=

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     pretty_env_logger::init();
 
-    let token = env::var("BOT_TOKEN")?;
+    let token = env::var("BOT_TOKEN")
+        .expect("Expected bot token in .env file");
     let http = Http::new_with_token(&token);
     let (owners, bot_id) = match http.get_current_application_info().await {
         Ok(info) => {
@@ -64,8 +65,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Err(why) => {
             warn!("Could not access application info: {:?}", why);
             warn!("Trying environment variable for bot id...");
-            let id = env::var("BOT_ID").expect("Unable to find BOT_ID environment variable");
-            let bot_id = id.parse::<u64>().expect("Invalid bot id");
+            let id = env::var("BOT_ID")
+                .expect("Unable to find BOT_ID environment variable");
+            let bot_id = id.parse::<u64>()
+                .expect("Invalid bot id");
             (HashSet::new(), serenity::model::id::UserId(bot_id))
         },
     };
@@ -79,8 +82,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .join(", ")
     );
 
-    let prefix = env::var("BOT_PREFIX")?;
-    let app_id = env::var("APPLICATION_ID")?;
+    let prefix = env::var("BOT_PREFIX")
+        .expect("Expected bot prefix in .env file");
+    let app_id = env::var("APPLICATION_ID")
+        .expect("Expected application id in .env file");
     let framework = StandardFramework::new()
         .configure(|c| c.owners(owners).prefix(&prefix))
         .before(events::before)

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -218,3 +218,16 @@ pub async fn send_global_presence(shard_manager : &MutexGuard<'_, ShardManager>,
         v.runner_tx.set_presence(Some(Activity::playing(&presence_str)), OnlineStatus::Online);
     }
 }
+
+pub async fn delete_bot_reacts(ctx : &Context, msg : &Message, react : ReactionType) -> CommandResult {
+    let bot_id = {
+        let data_read = ctx.data.read().await;
+        let botinfo_lock = data_read.get::<ConfigCache>().unwrap();
+        let botinfo = botinfo_lock.read().await;
+        let id = botinfo.get("BOT_ID").unwrap();
+        UserId::from(id.parse::<u64>().unwrap())
+    };
+
+    msg.channel_id.delete_reaction(&ctx.http, msg.id, Some(bot_id), react).await?;
+    Ok(())
+}


### PR DESCRIPTION
This patch changes how we handle the removal of reactions, a long overdue change which allows us to no longer require the manage messages permissions.

Thanks to erik and brain for recommending this change

Server owners are now recommended to disable this permission on the bot.

If you see an invite link that does not have the permissions value of `379968` please let me know, I've went ahead and changed every invite link location I could find, but it's possible I missed one.

This patch also ensures that the optional environment variables in .env are truly optional.