### PR TITLE
Fix argument endpoint detection on replies

### DIFF
--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -79,6 +79,29 @@ async fn standard_parse_url() {
 }
 
 #[tokio::test]
+async fn standard_parse_url_args() {
+    let dummy_user = User::default();
+    let input = indoc::indoc!(
+        ";compile c++ < https://pastebin.com/raw/ERqDRZva\ntest1 test2"
+    );
+
+    let reply = None;
+    let result = get_components(input, &dummy_user, None, &reply).await;
+    if let Err(_) = &result {
+        assert!(false, "Parser failed.");
+    }
+
+    let parser_result = result.unwrap();
+    println!("{:?}", &parser_result);
+    assert_eq!(parser_result.target, "c++");
+    assert_eq!(parser_result.args, ["test1", "test2"]);
+    assert_eq!(parser_result.options.len(), 0);
+    assert_eq!(parser_result.stdin, "");
+    assert_eq!(parser_result.url, "https://pastebin.com/raw/ERqDRZva");
+    assert_eq!(parser_result.code, "int main() {}");
+}
+
+#[tokio::test]
 async fn standard_parse_stdin() {
     let dummy_user = User::default();
     let input = indoc::indoc!(

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -41,7 +41,7 @@ pub async fn get_components(input: &str, author : &User, compilation_manager : O
     let mut result = ParserResult::default();
 
     // Find the index for where we should stop parsing user input
-    let mut end_point: usize = 0;
+    let mut end_point: usize = input.len();
     if let Some(parse_stop) = input.find("\n") {
         end_point = parse_stop;
     }
@@ -53,10 +53,7 @@ pub async fn get_components(input: &str, author : &User, compilation_manager : O
         else if index < end_point {
             end_point = index;
         }
-    } else {
-        end_point = input.len();
     }
-
     let mut args: Vec<&str> = input[..end_point].split_whitespace().collect();
     // ditch command str (;compile, ;asm)
     args.remove(0);


### PR DESCRIPTION
Continuing with our theme on improving replies today, this patch fixes an issue where the parser would fail to detect command line arguments and instead interpret them as options. 

Fixes #144 