### PR TITLE
Register application commands once

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,10 +33,8 @@ chrono = "0.4.19"
 
 [dependencies.serenity]
 version = "0.11"
-#git = "https://github.com/serenity-rs/serenity"
-#branch = "current"
 default-features = false
-features = ["collector", "gateway", "builder", "standard_framework", "http", "model", "client", "framework", "utils", "rustls_backend", "unstable_discord_api"]
+features = ["collector", "gateway", "builder", "standard_framework", "http", "model", "client", "framework", "utils", "rustls_backend"]
 
 [dependencies.wandbox]
 version = "0.1"

--- a/src/events.rs
+++ b/src/events.rs
@@ -253,13 +253,9 @@ impl EventHandler for Handler {
             }
         }
 
-        tokio::task::spawn(async move {
-            let ctx = ctx.clone();
-            let data = ctx.data.read().await;
-            let cmd_mgr = data.get::<CommandCache>().unwrap().read().await;
-            cmd_mgr.register_commands(&ctx).await;
-            info!("[Shard {}] Registered commands", ctx.shard_id);
-        });
+        let data = ctx.data.read().await;
+        let mut cmd_mgr = data.get::<CommandCache>().unwrap().write().await;
+        cmd_mgr.register_commands(&ctx).await;
     }
 
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {

--- a/src/managers/command.rs
+++ b/src/managers/command.rs
@@ -8,12 +8,14 @@ use serenity::model::interactions::application_command::ApplicationCommand;
 use crate::{cache::{CompilerCache}, slashcmds};
 use crate::cache::StatsManagerCache;
 
-pub struct CommandManager;
+pub struct CommandManager {
+    commands_registered : bool
+}
 
 impl CommandManager {
     pub fn new() -> Self {
         CommandManager {
-
+            commands_registered: false
         }
     }
 
@@ -57,7 +59,12 @@ impl CommandManager {
         }
     }
 
-    pub async fn register_commands(&self, ctx: &Context) {
+    pub async fn register_commands(&mut self, ctx: &Context) {
+        if self.commands_registered {
+            return
+        }
+        self.commands_registered = true;
+
         let data_read = ctx.data.read().await;
         let compiler_cache = data_read.get::<CompilerCache>().unwrap();
         let compiler_manager = compiler_cache.read().await;
@@ -101,5 +108,6 @@ impl CommandManager {
         }).await {
             error!("Unable to create application commands: {}", err);
         }
+        info!("Registered application commands");
     }
 }


### PR DESCRIPTION
We only need to register application commands once, not per shard. This speeds up some boot time and adds early exit logic for command registration if it's happened already.

Thanks to eirk#7057 for pointing this out.
