### PR TITLE
Increase error output length & correct compiler-explorer error lengths

### DIFF
--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -13,7 +13,7 @@ pub const ICON_INVITE: &str = "https://i.imgur.com/CZFt69d.png";
 //pub const COMPILER_EXPLORER_ICON: &str = "https://i.imgur.com/GIgATFr.png";
 pub const COMPILER_ICON: &str = "http://i.michaelwflaherty.com/u/XedLoQWCVc.png";
 pub const MAX_OUTPUT_LEN: usize = 250;
-pub const MAX_ERROR_LEN: usize = 500;
+pub const MAX_ERROR_LEN: usize = 956;
 pub const USER_AGENT : &str = const_format::formatcp!("discord-compiler-bot/{}", env!("CARGO_PKG_VERSION"));
 pub const URL_ALLOW_LIST : [&str; 4] = ["pastebin.com", "gist.githubusercontent.com", "hastebin.com", "raw.githubusercontent.com"];
 

--- a/src/utls/discordhelpers/embeds.rs
+++ b/src/utls/discordhelpers/embeds.rs
@@ -145,13 +145,13 @@ impl ToEmbed<bool> for godbolt::GodboltResponse {
             let stderr = errs.trim();
             let mut output = false;
             if !stdout.is_empty() {
-                let str = discordhelpers::conform_external_str(stdout,  MAX_ERROR_LEN);
+                let str = discordhelpers::conform_external_str(stdout,  MAX_OUTPUT_LEN);
                 embed.field("Program Output", format!("```\n{}\n```", str), false);
                 output = true;
             }
             if !stderr.is_empty() {
                 output = true;
-                let str = discordhelpers::conform_external_str(stderr, MAX_OUTPUT_LEN);
+                let str = discordhelpers::conform_external_str(stderr, MAX_ERROR_LEN);
                 embed.field("Compiler Output", format!("```\n{}\n```", str), false);
             }
 


### PR DESCRIPTION
Fixes #148 

Godbolt requests were limiting their error output by the wrong constant length, but we've also increased the error output length for languages like python which may have verbose traceback errors