### PR TITLE
Create boilerplate for popular languages

### DIFF
--- a/src/boilerplate/cpp.rs
+++ b/src/boilerplate/cpp.rs
@@ -1,0 +1,52 @@
+use regex::Regex;
+use crate::boilerplate::generator::BoilerPlateGenerator;
+
+pub struct CppGenerator {
+    input : String
+}
+
+impl BoilerPlateGenerator for CppGenerator {
+    fn new(input: &str) -> Self {
+        let mut formated = input.to_string();
+        formated = formated.replace(";", ";\n"); // separate lines by ;
+
+        Self {
+            input : formated
+        }
+    }
+
+    fn generate(&self) -> String {
+        let mut main_body = String::default();
+        let mut header = String::default();
+
+        let mut lines = self.input.split("\n");
+        while let Some(line) = lines.next() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("using") {
+                header.push_str(&format!("{}\n", trimmed));
+            }
+            else if trimmed.starts_with("#i") {
+                header.push_str(&format!("{}\n", trimmed));
+            }
+            else {
+                main_body.push_str(&format!("{}\n", trimmed))
+            }
+        }
+
+        // if they included nothing, we can just manually include everything
+        if !header.contains("#include") {
+            header.push_str("#include <bits/stdc++.h>");
+        }
+        format!("{}\nint main(void) {{\n{}return 0;\n}}", header, main_body)
+    }
+
+    fn needs_boilerplate(&self) -> bool {
+        let cpp_main_regex: Regex = Regex::new("\"[^\"]+\"|(?P<main>main[\\s]*?\\()").unwrap();
+        for m in cpp_main_regex.captures_iter(&self.input) {
+            if let Some(_) = m.name("main") {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/boilerplate/generator.rs
+++ b/src/boilerplate/generator.rs
@@ -1,0 +1,59 @@
+use crate::boilerplate::cpp::CppGenerator;
+use crate::boilerplate::java::JavaGenerator;
+
+pub trait BoilerPlateGenerator {
+    fn new(input : &str) -> Self where Self: Sized;
+    fn generate(&self) -> String;
+    fn needs_boilerplate(&self) -> bool;
+}
+
+pub struct BoilerPlate<T: ?Sized> where T: BoilerPlateGenerator {
+    generator : Box<T>
+}
+
+impl<T: ?Sized> BoilerPlate<T> where T: BoilerPlateGenerator{
+    pub fn new(generator : Box<T>) -> Self {
+        Self {
+            generator
+        }
+    }
+
+    pub fn generate(&self) -> String {
+        self.generator.generate()
+    }
+
+    pub fn needs_boilerplate(&self) -> bool {
+        self.generator.needs_boilerplate()
+    }
+}
+
+pub struct Null;
+impl BoilerPlateGenerator for Null {
+    fn new(_: &str) -> Self {
+        Self {}
+    }
+
+    fn generate(&self) -> String {
+        panic!("Cannot generate null boilerplate!");
+    }
+
+    fn needs_boilerplate(&self) -> bool {
+        false
+    }
+}
+
+pub fn boilerplate_factory(language : &str, code : &str)
+    -> BoilerPlate<dyn BoilerPlateGenerator> {
+    return match language {
+        "c++" => {
+            BoilerPlate::new(Box::new(CppGenerator::new(code)))
+        }
+        "java" => {
+            BoilerPlate::new(Box::new(JavaGenerator::new(code)))
+        }
+        unknown => {
+            warn!("Unknown boilerplate for: {}", unknown);
+            BoilerPlate::new(Box::new(Null::new(code)))
+        }
+    }
+}

--- a/src/boilerplate/java.rs
+++ b/src/boilerplate/java.rs
@@ -1,0 +1,45 @@
+use regex::Regex;
+use crate::boilerplate::generator::BoilerPlateGenerator;
+
+pub struct JavaGenerator {
+    input : String
+}
+
+impl BoilerPlateGenerator for JavaGenerator {
+    fn new(input: &str) -> Self {
+        let mut formated = input.to_string();
+        formated = formated.replace(";", ";\n"); // separate lines by ;
+
+        Self {
+            input : formated
+        }
+    }
+
+    fn generate(&self) -> String {
+        let mut main_body = String::default();
+        let mut header = String::default();
+
+        let mut lines = self.input.split("\n");
+        while let Some(line) = lines.next() {
+            let trimmed = line.trim();
+            if trimmed.starts_with("import") {
+                header.push_str(&format!("{}\n", trimmed));
+            }
+            else {
+                main_body.push_str(&format!("{}\n", trimmed))
+            }
+        }
+
+        format!("{}\nclass Main{{\npublic static void main(String[] args) {{\n{}}}}}", header, main_body)
+    }
+
+    fn needs_boilerplate(&self) -> bool {
+        let java_main_regex: Regex = Regex::new("\"[^\"]+\"|(?P<main>public[\\s]+?static[\\s]+?void[\\s]+?main[\\s]*?\\()").unwrap();
+        for m in java_main_regex.captures_iter(&self.input) {
+            if let Some(_) = m.name("main") {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/boilerplate/mod.rs
+++ b/src/boilerplate/mod.rs
@@ -1,0 +1,3 @@
+pub mod generator;
+pub mod cpp;
+pub mod java;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod cppeval;
 mod managers;
 mod tests;
 mod slashcmds;
+mod boilerplate;
 
 use serenity::{
     framework::{standard::macros::group, StandardFramework},

--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -6,6 +6,7 @@ use serenity::builder::CreateEmbed;
 
 use wandbox::{Wandbox, CompilationBuilder, WandboxError};
 use godbolt::{Godbolt, GodboltError, CompilationFilters, RequestOptions, CompilerOptions};
+use crate::boilerplate::generator::{boilerplate_factory};
 
 use crate::utls::parser::ParserResult;
 use crate::utls::discordhelpers::embeds::ToEmbed;
@@ -138,7 +139,19 @@ impl CompilationManager {
 
         let target = if parse_result.target == "haskell" { "ghc901" } else { &parse_result.target };
         let compiler = self.gbolt.resolve(target).unwrap();
-        let response = Godbolt::send_request(&compiler, &parse_result.code,  options, USER_AGENT).await?;
+
+        // replace boilerplate code if needed
+        let mut code = parse_result.code.clone();
+        {
+            let generator = boilerplate_factory(&compiler.lang, &code);
+            if generator.needs_boilerplate() {
+                code = generator.generate();
+            }
+            else {
+                warn!("Does not need boilerplate for language: {}", &compiler.lang);
+            }
+        }
+        let response = Godbolt::send_request(&compiler, &code,  options, USER_AGENT).await?;
         Ok((compiler.lang, response))
     }
 
@@ -162,8 +175,33 @@ impl CompilationManager {
     }
 
     pub async fn wandbox(&self, parse_result : &ParserResult) -> Result<(String, wandbox::CompilationResult), WandboxError> {
+        let lang = {
+            let mut found = String::default();
+            for lang in self.wbox.get_languages() {
+                if parse_result.target == lang.name {
+                    found = parse_result.target.clone();
+                }
+                for compiler in lang.compilers {
+                    if compiler.name == parse_result.target {
+                        found = lang.name.clone();
+                    }
+                }
+            }
+            if found.is_empty() {
+                warn!("Invalid target leaked checks and was caught before boilerplate creation")
+            }
+            found
+        };
+        let mut code = parse_result.code.clone();
+        {
+            let generator = boilerplate_factory(&lang, &code);
+            if generator.needs_boilerplate() {
+                code = generator.generate();
+            }
+        }
+
         let mut builder = CompilationBuilder::new();
-        builder.code(&parse_result.code);
+        builder.code(&code);
         builder.target(&parse_result.target);
         builder.stdin(&parse_result.stdin);
         builder.save(false);

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -13,7 +13,7 @@ pub const ICON_INVITE: &str = "https://i.imgur.com/CZFt69d.png";
 //pub const COMPILER_EXPLORER_ICON: &str = "https://i.imgur.com/GIgATFr.png";
 pub const COMPILER_ICON: &str = "http://i.michaelwflaherty.com/u/XedLoQWCVc.png";
 pub const MAX_OUTPUT_LEN: usize = 250;
-pub const MAX_ERROR_LEN: usize = 956;
+pub const MAX_ERROR_LEN: usize = 997;
 pub const USER_AGENT : &str = const_format::formatcp!("discord-compiler-bot/{}", env!("CARGO_PKG_VERSION"));
 pub const URL_ALLOW_LIST : [&str; 4] = ["pastebin.com", "gist.githubusercontent.com", "hastebin.com", "raw.githubusercontent.com"];
 


### PR DESCRIPTION
This is probably long overdue.

Something that sucks to do is to write a bunch of boilerplate every time you want to show someone something in a particular language. 

Our strategy now is as follows - if we cannot detect an entry point (which would lead to compilation failure), we will generate the boilerplate ourselves and reorder things as needed. Behavior for each language may be different, but follow the same overall idea. Let's look at how c++'s works

.compile
```cpp
#include <iostream>
int a = 5;
if (a < 24) {
  std::cout << "test";
}
```
Will get compiled to, as you can guess
```cpp
#include <iostream>

int main(void) {
int a = 5;
if (a < 24) {
  std::cout << "test";
}
return 0;
}
```

We'll be testing out this change on live bot for a little while to see if anything behaves in a way that's unexpected. My biggest concern is our main entry detection, we'll have to add in some tests for this to ensure that we're detecting mains correctly.