### PR TITLE
Improve boilerplate implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ async-trait = "0.1"
 content_inspector = "0.2"
 shell-words = "0.1"
 const_format = "0.2"
+lazy_static = "1.4.0"
 #tests
 indoc = "1.0.3"
 test-context = "0.1"

--- a/src/boilerplate/c.rs
+++ b/src/boilerplate/c.rs
@@ -1,11 +1,11 @@
 use crate::boilerplate::generator::BoilerPlateGenerator;
-use crate::utls::constants::CSHARP_MAIN_REGEX;
+use crate::utls::constants::C_LIKE_MAIN_REGEX;
 
-pub struct CSharpGenerator {
+pub struct CGenerator {
     input : String
 }
 
-impl BoilerPlateGenerator for CSharpGenerator {
+impl BoilerPlateGenerator for CGenerator {
     fn new(input: &str) -> Self {
         let mut formated = input.to_string();
         formated = formated.replace(";", ";\n"); // separate lines by ;
@@ -25,20 +25,22 @@ impl BoilerPlateGenerator for CSharpGenerator {
             if trimmed.starts_with("using") {
                 header.push_str(&format!("{}\n", trimmed));
             }
+            else if trimmed.starts_with("#i") {
+                header.push_str(&format!("{}\n", trimmed));
+            }
             else {
                 main_body.push_str(&format!("{}\n", trimmed))
             }
         }
 
-        // if they included nothing, we can just manually include System since they probably want it
-        if header.is_empty() {
-            header.push_str("using System;");
+        if main_body.contains("printf") && header.contains("stdio.h") {
+            header.push_str("include <stdio.h>")
         }
-        format!("{}\nnamespace Main{{\nclass Program {{\n static void Main(string[] args) {{\n{}}}}}}}", header, main_body)
+        format!("{}\nint main(void) {{\n{}return 0;\n}}", header, main_body)
     }
 
     fn needs_boilerplate(&self) -> bool {
-        for m in CSHARP_MAIN_REGEX.captures_iter(&self.input) {
+        for m in C_LIKE_MAIN_REGEX.captures_iter(&self.input) {
             if let Some(_) = m.name("main") {
                 return false;
             }

--- a/src/boilerplate/cpp.rs
+++ b/src/boilerplate/cpp.rs
@@ -1,5 +1,5 @@
-use regex::Regex;
 use crate::boilerplate::generator::BoilerPlateGenerator;
+use crate::utls::constants::C_LIKE_MAIN_REGEX;
 
 pub struct CppGenerator {
     input : String
@@ -41,8 +41,7 @@ impl BoilerPlateGenerator for CppGenerator {
     }
 
     fn needs_boilerplate(&self) -> bool {
-        let cpp_main_regex: Regex = Regex::new("\"[^\"]+\"|(?P<main>main[\\s]*?\\()").unwrap();
-        for m in cpp_main_regex.captures_iter(&self.input) {
+        for m in C_LIKE_MAIN_REGEX.captures_iter(&self.input) {
             if let Some(_) = m.name("main") {
                 return false;
             }

--- a/src/boilerplate/generator.rs
+++ b/src/boilerplate/generator.rs
@@ -1,3 +1,4 @@
+use crate::boilerplate::c::CGenerator;
 use crate::boilerplate::cpp::CppGenerator;
 use crate::boilerplate::csharp::CSharpGenerator;
 use crate::boilerplate::java::JavaGenerator;
@@ -46,8 +47,11 @@ impl BoilerPlateGenerator for Null {
 pub fn boilerplate_factory(language : &str, code : &str)
     -> BoilerPlate<dyn BoilerPlateGenerator> {
     return match language {
-        "c++" | "c" => {
+        "c++" => {
             BoilerPlate::new(Box::new(CppGenerator::new(code)))
+        }
+        "c" => {
+            BoilerPlate::new(Box::new(CGenerator::new(code)))
         }
         "java" => {
             BoilerPlate::new(Box::new(JavaGenerator::new(code)))

--- a/src/boilerplate/java.rs
+++ b/src/boilerplate/java.rs
@@ -1,5 +1,5 @@
-use regex::Regex;
 use crate::boilerplate::generator::BoilerPlateGenerator;
+use crate::utls::constants::JAVA_MAIN_REGEX;
 
 pub struct JavaGenerator {
     input : String
@@ -34,8 +34,7 @@ impl BoilerPlateGenerator for JavaGenerator {
     }
 
     fn needs_boilerplate(&self) -> bool {
-        let java_main_regex: Regex = Regex::new("\"[^\"]+\"|(?P<main>public[\\s]+?static[\\s]+?void[\\s]+?main[\\s]*?\\()").unwrap();
-        for m in java_main_regex.captures_iter(&self.input) {
+        for m in JAVA_MAIN_REGEX.captures_iter(&self.input) {
             if let Some(_) = m.name("main") {
                 return false;
             }

--- a/src/boilerplate/mod.rs
+++ b/src/boilerplate/mod.rs
@@ -2,3 +2,4 @@ pub mod generator;
 pub mod cpp;
 pub mod java;
 pub mod csharp;
+pub mod c;

--- a/src/tests/boilerplate/cpp.rs
+++ b/src/tests/boilerplate/cpp.rs
@@ -1,0 +1,51 @@
+#[cfg(test)]
+
+use crate::boilerplate::cpp::CppGenerator;
+use crate::boilerplate::generator::BoilerPlateGenerator;
+
+#[tokio::test]
+async fn standard_needs_boilerplate() {
+    let gen = CppGenerator::new("std::string str = \"test\";\n\
+    std::cout << str;");
+    assert!(gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate() {
+    let gen = CppGenerator::new("int main() {\n\
+    std::string str = \"test\";\n\
+    std::cout << str;\n\
+    return 0;\n\
+    }");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate2() {
+    let gen = CppGenerator::new("int main (    ) {\n\
+    std::string str = \"test\";\n\
+    std::cout << str;\n\
+    return 0;\n\
+    }");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate3() {
+    let gen = CppGenerator::new("int main\n(void) {\n\
+    std::string str = \"test\";\n\
+    std::cout << str;\n\
+    return 0;\n\
+    }");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate4() {
+    let gen = CppGenerator::new("void main    (void) {\n\
+    std::string str = \"test\";\n\
+    std::cout << str;\n\
+    return 0;\n\
+    }");
+    assert!(!gen.needs_boilerplate());
+}

--- a/src/tests/boilerplate/java.rs
+++ b/src/tests/boilerplate/java.rs
@@ -1,0 +1,47 @@
+#[cfg(test)]
+
+use crate::boilerplate::java::JavaGenerator;
+use crate::boilerplate::generator::BoilerPlateGenerator;
+
+#[tokio::test]
+async fn standard_needs_boilerplate() {
+    let gen = JavaGenerator::new("String str = \"test\";\n\
+    System.out.println(str)");
+    assert!(gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static void main(String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate2() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static void main (String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate3() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static void main\t(String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate4() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static void main                               (String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+}

--- a/src/tests/boilerplate/java.rs
+++ b/src/tests/boilerplate/java.rs
@@ -45,3 +45,12 @@ async fn standard_doesnt_need_boilerplate4() {
     }\n");
     assert!(!gen.needs_boilerplate());
 }
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate5() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static final void main                               (String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+}

--- a/src/tests/boilerplate/mod.rs
+++ b/src/tests/boilerplate/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+pub mod cpp;
+#[cfg(test)]
+pub mod java;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,3 +2,4 @@
 
 pub mod parser;
 pub mod cpp;
+pub mod boilerplate;

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -1,9 +1,7 @@
 use lazy_static::lazy_static;
 use regex::Regex;
 
-//pub const COLOR_OKAY : i32 = 0x046604;
 pub const COLOR_OKAY: u32 = 0x5dbcd2;
-//pub const COLOR_FAIL : i32 = 0x660404;
 pub const COLOR_FAIL: u32 = 0xff7761;
 pub const COLOR_WARN: u32 = 0xad7805;
 
@@ -11,12 +9,13 @@ pub const ICON_FAIL: &str = "https://i.imgur.com/LxxYrFj.png";
 pub const ICON_VOTE: &str = "https://i.imgur.com/VXbdwSQ.png";
 pub const ICON_HELP: &str = "https://i.imgur.com/TNzxfMB.png";
 pub const ICON_INVITE: &str = "https://i.imgur.com/CZFt69d.png";
-//pub const COMPILER_EXPLORER_ICON: &str = "https://i.imgur.com/GIgATFr.png";
 pub const COMPILER_ICON: &str = "http://i.michaelwflaherty.com/u/XedLoQWCVc.png";
-pub const MAX_OUTPUT_LEN: usize = 250;
-pub const MAX_ERROR_LEN: usize = 997;
 pub const USER_AGENT : &str = const_format::formatcp!("discord-compiler-bot/{}", env!("CARGO_PKG_VERSION"));
 pub const URL_ALLOW_LIST : [&str; 4] = ["pastebin.com", "gist.githubusercontent.com", "hastebin.com", "raw.githubusercontent.com"];
+
+pub const MAX_OUTPUT_LEN: usize = 250;
+pub const MAX_ERROR_LEN: usize = 997;
+
 
 // Boilerplate Regexes
 lazy_static! {

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -20,7 +20,7 @@ pub const URL_ALLOW_LIST : [&str; 4] = ["pastebin.com", "gist.githubusercontent.
 
 // Boilerplate Regexes
 lazy_static! {
-    pub static ref JAVA_MAIN_REGEX: Regex = Regex::new("\"[^\"]+\"|(?P<main>public[\\s]+?static[\\s]+?void[\\s]+?main[\\s]*?\\()").unwrap();
+    pub static ref JAVA_MAIN_REGEX: Regex = Regex::new("\"[^\"]+\"|(?P<main>void[\\s]+?main[\\s]*?\\()").unwrap();
     pub static ref C_LIKE_MAIN_REGEX: Regex = Regex::new("\"[^\"]+\"|(?P<main>main[\\s]*?\\()").unwrap();
     pub static ref CSHARP_MAIN_REGEX: Regex = Regex::new("\"[^\"]+\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
 }

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -1,4 +1,5 @@
-
+use lazy_static::lazy_static;
+use regex::Regex;
 
 //pub const COLOR_OKAY : i32 = 0x046604;
 pub const COLOR_OKAY: u32 = 0x5dbcd2;
@@ -17,7 +18,12 @@ pub const MAX_ERROR_LEN: usize = 997;
 pub const USER_AGENT : &str = const_format::formatcp!("discord-compiler-bot/{}", env!("CARGO_PKG_VERSION"));
 pub const URL_ALLOW_LIST : [&str; 4] = ["pastebin.com", "gist.githubusercontent.com", "hastebin.com", "raw.githubusercontent.com"];
 
-
+// Boilerplate Regexes
+lazy_static! {
+    pub static ref JAVA_MAIN_REGEX: Regex = Regex::new("\"[^\"]+\"|(?P<main>public[\\s]+?static[\\s]+?void[\\s]+?main[\\s]*?\\()").unwrap();
+    pub static ref C_LIKE_MAIN_REGEX: Regex = Regex::new("\"[^\"]+\"|(?P<main>main[\\s]*?\\()").unwrap();
+    pub static ref CSHARP_MAIN_REGEX: Regex = Regex::new("\"[^\"]+\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
+}
 /*
     Discord limits the size of the amount of compilers we can display to users, for some languages
     we'll just grab the first 25 from our API, for C & C++ we will create a curated list manually.


### PR DESCRIPTION
Fixes #152 
This is an extension to the boilerplate implementation, we'll see a few things developed on this branch.

This patch will move some of the regex creation to be in the `constants.rs` and prevent regex recompilation after every compilation request, something that we needed to bring `lazy_static` in to accomplish.

Our end goal is to move function declarations out of main methods, that way functions can be created and moved to their correct places as needed.

We'll need a regex made that allows us to detect function definitions. Unlike our main regexes, we'd need to match functions that could have templated/generic return types. Let's use C++ as an example.

```cpp
std::vector < int > myfunc(int a, int b) {
    return std::vector{a, b};
}
for (auto i : myfunc(3, 5)) {
    std::cout << i << std::endl;
}
```

A request in this form should not trip up our detection, so correctly matching any function call regardless of it's return type form might be tricky, we'll have to see.