### PR TITLE
Fix java compilations with public keyword

### DIFF
--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -32,6 +32,13 @@ lazy_static! {
         Regex::new("\"[^\"]+\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
 }
 
+// Other Regexes
+lazy_static! {
+    pub static ref JAVA_PUBLIC_CLASS_REGEX: Regex =
+        Regex::new("\"[^\"]+\"|(?P<public>public)[\\s]+?class[\\s]*?").unwrap();
+}
+
+
 /*
    Discord limits the size of the amount of compilers we can display to users, for some languages
    we'll just grab the first 25 from our API, for C & C++ we will create a curated list manually.

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -182,7 +182,6 @@ pub async fn get_components(
         return Err(CommandError::from("You must provide a valid language or compiler!\n\n;compile c++ \n\\`\\`\\`\nint main() {}\n\\`\\`\\`"));
     }
 
-    //println!("Parse object: {:?}", result);
     Ok(result)
 }
 


### PR DESCRIPTION
This is a common pain point for newer Java users, we'll just automatically remove the `public` keyword from class definitions to ensure their code compiles.