### PR TITLE
Implement command to allow diffing code-blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ content_inspector = "0.2"
 shell-words = "0.1"
 const_format = "0.2"
 lazy_static = "1.4.0"
+similar = "2.1.0"
 #tests
 indoc = "1.0.3"
 test-context = "0.1"

--- a/src/events.rs
+++ b/src/events.rs
@@ -10,9 +10,6 @@ use serenity::{
 use tokio::sync::MutexGuard;
 
 use chrono::{DateTime, Utc};
-use serenity::model::interactions::application_command::{
-    ApplicationCommandOptionType, ApplicationCommandType,
-};
 
 use crate::{
     cache::*,
@@ -64,27 +61,6 @@ impl ShardsReadyHandler for Handler {
 #[async_trait]
 impl EventHandler for Handler {
     async fn guild_create(&self, ctx: Context, guild: Guild) {
-        guild
-            .create_application_command(&ctx.http, |cmd| {
-                cmd.kind(ApplicationCommandType::ChatInput)
-                    .name("diff")
-                    .description("Posts a diff of two messages' code blocks.")
-                    .create_option(|opt| {
-                        opt.required(true)
-                            .name("message1")
-                            .kind(ApplicationCommandOptionType::String)
-                            .description("Message id of first code-block")
-                    })
-                    .create_option(|opt| {
-                        opt.required(true)
-                            .name("message2")
-                            .kind(ApplicationCommandOptionType::String)
-                            .description("Message id of second code-block")
-                    })
-            })
-            .await
-            .unwrap();
-
         let data = ctx.data.read().await;
 
         let now: DateTime<Utc> = Utc::now();

--- a/src/events.rs
+++ b/src/events.rs
@@ -10,6 +10,9 @@ use serenity::{
 use tokio::sync::MutexGuard;
 
 use chrono::{DateTime, Utc};
+use serenity::model::interactions::application_command::{
+    ApplicationCommandOptionType, ApplicationCommandType,
+};
 
 use crate::{
     cache::*,
@@ -61,6 +64,27 @@ impl ShardsReadyHandler for Handler {
 #[async_trait]
 impl EventHandler for Handler {
     async fn guild_create(&self, ctx: Context, guild: Guild) {
+        guild
+            .create_application_command(&ctx.http, |cmd| {
+                cmd.kind(ApplicationCommandType::ChatInput)
+                    .name("diff")
+                    .description("Posts a diff of two messages' code blocks.")
+                    .create_option(|opt| {
+                        opt.required(true)
+                            .name("message1")
+                            .kind(ApplicationCommandOptionType::String)
+                            .description("Message id of first code-block")
+                    })
+                    .create_option(|opt| {
+                        opt.required(true)
+                            .name("message2")
+                            .kind(ApplicationCommandOptionType::String)
+                            .description("Message id of second code-block")
+                    })
+            })
+            .await
+            .unwrap();
+
         let data = ctx.data.read().await;
 
         let now: DateTime<Utc> = Utc::now();

--- a/src/managers/command.rs
+++ b/src/managers/command.rs
@@ -46,6 +46,7 @@ impl CommandManager {
             "cpp" => slashcmds::cpp::cpp(ctx, command).await,
             "invite" => slashcmds::invite::invite(ctx, command).await,
             "format" => slashcmds::format::format(ctx, command).await,
+            "diff" => slashcmds::diff::diff(ctx, command).await,
             e => {
                 println!("OTHER: {}", e);
                 Ok(())
@@ -107,7 +108,6 @@ impl CommandManager {
                                 .description("Geordi-like input")
                         })
                 });
-
                 builder
             })
             .await

--- a/src/managers/command.rs
+++ b/src/managers/command.rs
@@ -108,6 +108,23 @@ impl CommandManager {
                                 .description("Geordi-like input")
                         })
                 });
+                builder.create_application_command(|cmd| {
+                    cmd.kind(ApplicationCommandType::ChatInput)
+                        .name("diff")
+                        .description("Posts a diff of two messages' code blocks.")
+                        .create_option(|opt| {
+                            opt.required(true)
+                                .name("message1")
+                                .kind(ApplicationCommandOptionType::String)
+                                .description("Message id of first code-block")
+                        })
+                        .create_option(|opt| {
+                            opt.required(true)
+                                .name("message2")
+                                .kind(ApplicationCommandOptionType::String)
+                                .description("Message id of second code-block")
+                        })
+                });
                 builder
             })
             .await

--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -261,8 +261,6 @@ fn fix_common_problems(language: &str, code: String) -> String {
             }
             fix_candidate
         }
-        _ => {
-            code
-        }
-    }
+        _ => code,
+    };
 }

--- a/src/slashcmds/diff.rs
+++ b/src/slashcmds/diff.rs
@@ -1,0 +1,138 @@
+use serenity::{
+    framework::standard::CommandResult,
+    model::interactions::application_command::ApplicationCommandInteraction,
+    model::interactions::application_command::ApplicationCommandInteractionDataOptionValue,
+    model::prelude::*, prelude::*,
+};
+
+use similar::ChangeTag;
+
+use crate::{
+    utls::constants::COLOR_FAIL, utls::constants::COLOR_OKAY, utls::parser::find_code_block,
+    utls::parser::ParserResult,
+};
+
+pub async fn diff(ctx: &Context, msg: &ApplicationCommandInteraction) -> CommandResult {
+    let message1 = msg
+        .data
+        .options
+        .get(0)
+        .expect("Expected interaction option 0")
+        .resolved
+        .as_ref()
+        .expect("Expected data option value");
+
+    let message2 = msg
+        .data
+        .options
+        .get(1)
+        .expect("Expected interaction option 1")
+        .resolved
+        .as_ref()
+        .expect("Expected data option value");
+
+    let mut message1_parse = None;
+    if let ApplicationCommandInteractionDataOptionValue::String(input) = message1 {
+        message1_parse = input.parse::<u64>().ok();
+    }
+    let mut message2_parse = None;
+    if let ApplicationCommandInteractionDataOptionValue::String(input) = message2 {
+        message2_parse = input.parse::<u64>().ok();
+    }
+
+    if message1_parse.is_none() || message2_parse.is_none() {
+        msg.create_interaction_response(&ctx.http, |resp| {
+            resp.interaction_response_data(|data| {
+                data.embed(|emb| {
+                    emb.color(COLOR_FAIL).description(
+                        "Invalid message ID specified!\n\n\
+                        Right click a message and select 'Copy ID' at the bottom. If you cannot \
+                        see this option then you must first enable Developer Mode by going to the \
+                        User Settings > Advanced tab",
+                    )
+                })
+                .flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+            })
+        })
+        .await?;
+        return Ok(());
+    }
+
+    let message1_obj = ctx
+        .http
+        .get_message(msg.channel_id.0, message1_parse.unwrap())
+        .await
+        .ok();
+    let message2_obj = ctx
+        .http
+        .get_message(msg.channel_id.0, message2_parse.unwrap())
+        .await
+        .ok();
+    if message1_obj.is_none() || message2_obj.is_none() {
+        msg.create_interaction_response(&ctx.http, |resp| {
+            resp.interaction_response_data(|data| {
+                data.embed(|emb| {
+                    emb.color(COLOR_FAIL).description(
+                        "Unable to find message.\n\nEnsure both messages belong to \
+                        this channel and the Message IDs are correct.",
+                    )
+                })
+                .flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+            })
+        })
+        .await?;
+        return Ok(());
+    }
+
+    let content1 = message1_obj.unwrap().content;
+    let content2 = message2_obj.unwrap().content;
+
+    let mut fake_parse1 = ParserResult::default();
+    let mut fake_parse2 = ParserResult::default();
+
+    {
+        let block1 = find_code_block(&mut fake_parse1, &content1, &msg.user);
+        let block2 = find_code_block(&mut fake_parse2, &content2, &msg.user);
+
+        if !block1.await? || !block2.await? {
+            msg.create_interaction_response(&ctx.http, |resp| {
+                resp.interaction_response_data(|data| {
+                    data.embed(|emb| {
+                        emb.color(COLOR_FAIL).description(
+                            "Unable to find a code-block to match within a supplied message!",
+                        )
+                    })
+                    .flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+                })
+            })
+            .await?;
+            return Ok(());
+        }
+    }
+
+    let code1 = fake_parse1.code.clone();
+    let code2 = fake_parse2.code.clone();
+    let diff = similar::TextDiff::from_lines(&code1, &code2);
+    let mut output = String::new();
+    for change in diff.iter_all_changes() {
+        let sign = match change.tag() {
+            ChangeTag::Delete => "-",
+            ChangeTag::Insert => "+",
+            ChangeTag::Equal => " ",
+        };
+        output.push_str(&format!("{}{}", sign, change));
+    }
+
+    msg.create_interaction_response(&ctx.http, |resp| {
+        resp.interaction_response_data(|data| {
+            data.embed(|emb| {
+                emb.color(COLOR_OKAY)
+                    .title("Diff completed")
+                    .description(format!("```diff\n{}\n```", output))
+            })
+        })
+    })
+    .await?;
+
+    Ok(())
+}

--- a/src/slashcmds/mod.rs
+++ b/src/slashcmds/mod.rs
@@ -1,6 +1,7 @@
 pub mod asm;
 pub mod compile;
 pub mod cpp;
+pub mod diff;
 pub mod format;
 pub mod help;
 pub mod invite;

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -38,7 +38,6 @@ lazy_static! {
         Regex::new("\"[^\"]+\"|(?P<public>public)[\\s]+?class[\\s]*?").unwrap();
 }
 
-
 /*
    Discord limits the size of the amount of compilers we can display to users, for some languages
    we'll just grab the first 25 from our API, for C & C++ we will create a curated list manually.

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -262,13 +262,12 @@ pub async fn manual_dispatch(http: Arc<Http>, id: u64, emb: CreateEmbed) {
     };
 }
 
-pub async fn send_global_presence(shard_manager : &MutexGuard<'_, ShardManager>, sum : u64) {
+pub async fn send_global_presence(shard_manager: &MutexGuard<'_, ShardManager>, sum: u64) {
     let server_count = {
         if sum < 10000 {
             sum.to_string()
-        }
-        else {
-            format!("{:.1}k", sum/1000)
+        } else {
+            format!("{:.1}k", sum / 1000)
         }
     };
 


### PR DESCRIPTION
This command (implemented as a slash command) allows users to diff code-blocks as they wish.

Sometimes it's difficult to quickly identify changes people make between posts, so this command will help isolate those changes in a diff format.