### PR TITLE
Register commands differently based off debug or release builds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .join(", ")
     );
 
+    if cfg!(debug_assertions) {
+        warn!("Running bot in DEBUG mode...");
+    }
+
     let prefix = env::var("BOT_PREFIX").expect("Expected bot prefix in .env file");
     let app_id = env::var("APPLICATION_ID").expect("Expected application id in .env file");
     let framework = StandardFramework::new()

--- a/src/managers/command.rs
+++ b/src/managers/command.rs
@@ -1,23 +1,28 @@
 use crate::cache::StatsManagerCache;
-use crate::{cache::CompilerCache, slashcmds};
-use serenity::model::interactions::application_command::ApplicationCommand;
+use crate::slashcmds;
+
 use serenity::{
+    builder::CreateApplicationCommand,
     client::Context,
     framework::standard::CommandResult,
-    model::interactions::application_command::{
-        ApplicationCommandInteraction, ApplicationCommandOptionType, ApplicationCommandType,
+    model::{
+        guild::Guild, interactions::application_command::ApplicationCommand,
+        interactions::application_command::ApplicationCommandInteraction,
+        interactions::application_command::ApplicationCommandOptionType,
+        interactions::application_command::ApplicationCommandType,
     },
 };
-use std::collections::HashMap;
 
 pub struct CommandManager {
     commands_registered: bool,
+    commands: Vec<CreateApplicationCommand>,
 }
 
 impl CommandManager {
     pub fn new() -> Self {
         CommandManager {
             commands_registered: false,
+            commands: CommandManager::build_commands(),
         }
     }
 
@@ -39,98 +44,148 @@ impl CommandManager {
         }
 
         match command_name.as_str() {
-            "compile" => slashcmds::compile::compile(ctx, command).await,
-            "assembly" => slashcmds::asm::asm(ctx, command).await,
+            "compile" | "compile [beta]" => slashcmds::compile::compile(ctx, command).await,
+            "assembly" | "assembly [beta]" => slashcmds::asm::asm(ctx, command).await,
             "ping" => slashcmds::ping::ping(ctx, command).await,
             "help" => slashcmds::help::help(ctx, command).await,
             "cpp" => slashcmds::cpp::cpp(ctx, command).await,
             "invite" => slashcmds::invite::invite(ctx, command).await,
-            "format" => slashcmds::format::format(ctx, command).await,
+            "format" | "format [beta]" => slashcmds::format::format(ctx, command).await,
             "diff" => slashcmds::diff::diff(ctx, command).await,
             e => {
-                println!("OTHER: {}", e);
+                warn!("Unknown application command received: {}", e);
                 Ok(())
             }
         }
     }
 
-    pub async fn register_commands(&mut self, ctx: &Context) {
+    pub async fn remove_guild_commands(ctx: &Context, guild: &Guild) {
+        if let Ok(commands) = guild.get_application_commands(&ctx.http).await {
+            for cmd in commands {
+                let _ = guild.delete_application_command(&ctx.http, cmd.id).await;
+            }
+        }
+    }
+
+    pub async fn register_commands_guild(&mut self, ctx: &Context, guild: &Guild) {
+        match guild
+            .set_application_commands(&ctx.http, |setter| {
+                setter.set_application_commands(self.commands.clone())
+            })
+            .await
+        {
+            Err(e) => error!(
+                "Unable to set application commands for guild '{}': {}",
+                guild.id, e
+            ),
+            Ok(commands) => info!(
+                "Registered {} commands in guild: {}",
+                commands.len(),
+                guild.id
+            ),
+        }
+    }
+
+    pub async fn register_commands_global(&mut self, ctx: &Context) {
         if self.commands_registered {
             return;
         }
         self.commands_registered = true;
 
-        let data_read = ctx.data.read().await;
-        let compiler_cache = data_read.get::<CompilerCache>().unwrap();
-        let compiler_manager = compiler_cache.read().await;
-
-        let mut godbolt_dict = HashMap::new();
-        for cache_entry in &compiler_manager.gbolt.cache {
-            godbolt_dict.insert(
-                cache_entry.language.name.clone(),
-                cache_entry.language.id.clone(),
-            );
-        }
-        if let Err(err) =
-            ApplicationCommand::set_global_application_commands(&ctx.http, |builder| {
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::Message).name("Compile")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::Message).name("Assembly")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::Message).name("Format")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("help")
-                        .description("Information on how to use the compiler")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("invite")
-                        .description("Grab my invite link to invite me to your server")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("ping")
-                        .description("Test my ping to Discord's endpoint")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("cpp")
-                        .description("Shorthand C++ compilation using geordi-like syntax")
-                        .create_option(|opt| {
-                            opt.required(false)
-                                .name("input")
-                                .kind(ApplicationCommandOptionType::String)
-                                .description("Geordi-like input")
-                        })
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("diff")
-                        .description("Posts a diff of two messages' code blocks.")
-                        .create_option(|opt| {
-                            opt.required(true)
-                                .name("message1")
-                                .kind(ApplicationCommandOptionType::String)
-                                .description("Message id of first code-block")
-                        })
-                        .create_option(|opt| {
-                            opt.required(true)
-                                .name("message2")
-                                .kind(ApplicationCommandOptionType::String)
-                                .description("Message id of second code-block")
-                        })
-                });
-                builder
-            })
-            .await
+        match ApplicationCommand::set_global_application_commands(&ctx.http, |setter| {
+            setter.set_application_commands(self.commands.clone())
+        })
+        .await
         {
-            error!("Unable to create application commands: {}", err);
+            Ok(cmds) => info!("Registered {} application commands", cmds.len()),
+            Err(e) => error!("Unable to set application commands: {}", e),
         }
-        info!("Registered application commands");
+    }
+
+    pub fn build_commands() -> Vec<CreateApplicationCommand> {
+        let mut cmds = Vec::new();
+
+        let mut cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::Message).name(format!(
+            "Compile{}",
+            if cfg!(debug_assertions) {
+                " [BETA]"
+            } else {
+                ""
+            }
+        ));
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::Message).name(format!(
+            "Assembly{}",
+            if cfg!(debug_assertions) {
+                " [BETA]"
+            } else {
+                ""
+            }
+        ));
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::Message).name(format!(
+            "Format{}",
+            if cfg!(debug_assertions) {
+                " [BETA]"
+            } else {
+                ""
+            }
+        ));
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("help")
+            .description("Information on how to use the compiler");
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("invite")
+            .description("Grab my invite link to invite me to your server");
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("ping")
+            .description("Test my ping to Discord's endpoint");
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("cpp")
+            .description("Shorthand C++ compilation using geordi-like syntax")
+            .create_option(|opt| {
+                opt.required(false)
+                    .name("input")
+                    .kind(ApplicationCommandOptionType::String)
+                    .description("Geordi-like input")
+            });
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("diff")
+            .description("Posts a diff of two message code blocks")
+            .create_option(|opt| {
+                opt.required(true)
+                    .name("message1")
+                    .kind(ApplicationCommandOptionType::String)
+                    .description("Message id of first code-block")
+            })
+            .create_option(|opt| {
+                opt.required(true)
+                    .name("message2")
+                    .kind(ApplicationCommandOptionType::String)
+                    .description("Message id of second code-block")
+            });
+        cmds.push(cmd);
+
+        cmds
     }
 }


### PR DESCRIPTION
This patch will automatically register commands on a per-guild basis if built in debug mode. This is useful for speeding up command development workflow.

Furthermore, we'll identify commands registered per guild in the `Apps >` dropdown by specifying that it is a `[BETA]` command. This became quite confusing in situations where both the development bot and the live bot exist within the same server. 