### PR TITLE
Remove emojis from compilation edits properly w/o manage messages

### DIFF
--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -88,7 +88,13 @@ pub async fn handle_edit(
     };
 
     // try to clear reactions
-    let _ = old.delete_reactions(&ctx).await;
+    if let Ok(updated_message) = old.channel_id.message(&ctx.http, old.id.0).await {
+        for reaction in &updated_message.reactions {
+            if reaction.me {
+                let _ = discordhelpers::delete_bot_reacts(ctx, &updated_message, reaction.reaction_type.clone()).await;
+            }
+        }
+    }
 
     if content.starts_with(&format!("{}asm", prefix)) {
         if let Err(e) = handle_edit_asm(


### PR DESCRIPTION
This was a regression from #141, I missed a case.

This lead to the bot leaving it's previous reaction emoji if a compilation request was edited.