### PR TITLE
Add php boiler plate generation & fix boilerplate detect on empty string literal

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "cargo fmt && cargo clippy -- -Dwarnings && cargo test"
+pre-commit = "cargo fmt -- --check && cargo clippy -- -Dwarnings && cargo test"
 
 [logging]
 verbose = true

--- a/src/boilerplate/generator.rs
+++ b/src/boilerplate/generator.rs
@@ -1,7 +1,7 @@
-use crate::boilerplate::c::CGenerator;
-use crate::boilerplate::cpp::CppGenerator;
-use crate::boilerplate::csharp::CSharpGenerator;
-use crate::boilerplate::java::JavaGenerator;
+use crate::boilerplate::{
+    c::CGenerator, cpp::CppGenerator, csharp::CSharpGenerator, java::JavaGenerator,
+    php::PHPGenerator,
+};
 
 pub trait BoilerPlateGenerator {
     fn new(input: &str) -> Self
@@ -56,6 +56,7 @@ pub fn boilerplate_factory(language: &str, code: &str) -> BoilerPlate<dyn Boiler
         "c" => BoilerPlate::new(Box::new(CGenerator::new(code))),
         "java" => BoilerPlate::new(Box::new(JavaGenerator::new(code))),
         "c#" => BoilerPlate::new(Box::new(CSharpGenerator::new(code))),
+        "php" => BoilerPlate::new(Box::new(PHPGenerator::new(code))),
         // since all compilations go through this path, we have a Null generator whose
         // needs_boilerplate() always returns false.
         _ => BoilerPlate::new(Box::new(Null::new(code))),

--- a/src/boilerplate/mod.rs
+++ b/src/boilerplate/mod.rs
@@ -3,3 +3,4 @@ pub mod cpp;
 pub mod csharp;
 pub mod generator;
 pub mod java;
+pub mod php;

--- a/src/boilerplate/php.rs
+++ b/src/boilerplate/php.rs
@@ -1,0 +1,28 @@
+use crate::boilerplate::generator::BoilerPlateGenerator;
+use crate::utls::constants::PHP_START_REGEX;
+
+pub struct PHPGenerator {
+    input: String,
+}
+
+impl BoilerPlateGenerator for PHPGenerator {
+    fn new(input: &str) -> Self {
+        let mut formated = input.to_string();
+        formated = formated.replace(';', ";\n"); // separate lines by ;
+
+        Self { input: formated }
+    }
+
+    fn generate(&self) -> String {
+        format!("<?php\n{}", self.input)
+    }
+
+    fn needs_boilerplate(&self) -> bool {
+        for m in PHP_START_REGEX.captures_iter(&self.input) {
+            if m.name("php_start").is_some() {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -25,17 +25,17 @@ pub const MAX_ERROR_LEN: usize = 997;
 // Boilerplate Regexes
 lazy_static! {
     pub static ref JAVA_MAIN_REGEX: Regex =
-        Regex::new("\"[^\"]+\"|(?P<main>void[\\s]+?main[\\s]*?\\()").unwrap();
+        Regex::new("\"[^\"]*?\"|(?P<main>void[\\s]+?main[\\s]*?\\()").unwrap();
     pub static ref C_LIKE_MAIN_REGEX: Regex =
-        Regex::new("\"[^\"]+\"|(?P<main>main[\\s]*?\\()").unwrap();
+        Regex::new("\"[^\"]*?\"|(?P<main>main[\\s]*?\\()").unwrap();
     pub static ref CSHARP_MAIN_REGEX: Regex =
-        Regex::new("\"[^\"]+\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
+        Regex::new("\"[^\"]*?\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
 }
 
 // Other Regexes
 lazy_static! {
     pub static ref JAVA_PUBLIC_CLASS_REGEX: Regex =
-        Regex::new("\"[^\"]+\"|(?P<public>public)[\\s]+?class[\\s]*?").unwrap();
+        Regex::new("\"[^\"]*?\"|(?P<public>public)[\\s]+?class[\\s]*?").unwrap();
 }
 
 /*

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -30,6 +30,8 @@ lazy_static! {
         Regex::new("\"[^\"]*?\"|(?P<main>main[\\s]*?\\()").unwrap();
     pub static ref CSHARP_MAIN_REGEX: Regex =
         Regex::new("\"[^\"]*?\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
+    pub static ref PHP_START_REGEX: Regex =
+        Regex::new("\"[^\"]*?\"|(?P<php_start><\\?php)").unwrap();
 }
 
 // Other Regexes

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -91,7 +91,12 @@ pub async fn handle_edit(
     if let Ok(updated_message) = old.channel_id.message(&ctx.http, old.id.0).await {
         for reaction in &updated_message.reactions {
             if reaction.me {
-                let _ = discordhelpers::delete_bot_reacts(ctx, &updated_message, reaction.reaction_type.clone()).await;
+                let _ = discordhelpers::delete_bot_reacts(
+                    ctx,
+                    &updated_message,
+                    reaction.reaction_type.clone(),
+                )
+                .await;
             }
         }
     }


### PR DESCRIPTION
This patch brings in the adding the php preamble as a boilerplate generator, in case the user didn't supply one.

I also fixed a bug where some compilations were falsely detected as not containing their main methods when they actually were. This was caused by the regex always consuming the next character when a `"` was found.