### PR TITLE
Add more bplate test coverage for C++ & Java

### DIFF
--- a/src/tests/boilerplate/cpp.rs
+++ b/src/tests/boilerplate/cpp.rs
@@ -58,3 +58,29 @@ async fn standard_doesnt_need_boilerplate4() {
     );
     assert!(!gen.needs_boilerplate());
 }
+
+#[tokio::test]
+async fn no_bplate_emptystrlit() {
+    let gen = CppGenerator::new(
+        "#include \"stdio.h\"
+        int x = sizeof \"\" + '0';
+        int main() {
+          printf(\"%d\n\", x);
+        }",
+    );
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn no_bplate_narfd_main() {
+    let gen = CppGenerator::new(
+        "#include \"stdio.h\"
+            #define NARF void
+            #define ZORT signed
+            int x = '1';
+            ZORT main (NARF) {
+              printf(\"%d\n\", x);
+            }",
+    );
+    assert!(!gen.needs_boilerplate());
+}

--- a/src/tests/boilerplate/java.rs
+++ b/src/tests/boilerplate/java.rs
@@ -65,3 +65,80 @@ async fn standard_doesnt_need_boilerplate5() {
     );
     assert!(!gen.needs_boilerplate());
 }
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate6() {
+    let gen = JavaGenerator::new(
+        "class Test {\n\
+    static public final void main                               (String[] args) {\n\
+    }\n\
+    }\n",
+    );
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate7() {
+    let gen = JavaGenerator::new(
+        "class Test {\n\
+    static final public void main                               (String[] args) {\n\
+    }\n\
+    }\n",
+    );
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate8() {
+    let gen = JavaGenerator::new(
+        "class Test {\n\
+    final static public void main                               (String[] args) {\n\
+    }\n\
+    }\n",
+    );
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate9() {
+    let gen = JavaGenerator::new(
+        "class Test {\n\
+    final public static void main                               (String[] args) {\n\
+    }\n\
+    }\n",
+    );
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate10() {
+    let gen = JavaGenerator::new(
+        "class Test {\n\
+    public @SuppressWarnings(\"all\") final static void main ( final String args[] ) {\n\
+    }\n\
+    }\n",
+    );
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate11() {
+    let gen = JavaGenerator::new(
+        "class Test {\n\
+    public @SuppressWarnings(\"all\") static final void main ( final String args[] ) {\n\
+    }\n\
+    }\n",
+    );
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate12() {
+    let gen = JavaGenerator::new(
+        "class Test {\n\
+    public @SuppressWarnings(\"all\") static void main ( final String args[] ) {\n\
+    }\n\
+    }\n",
+    );
+    assert!(!gen.needs_boilerplate());
+}


### PR DESCRIPTION
Fixes #162 .. kinda

#162 was fixed by #160, but due to a configuration error, the change was never deployed.

This patch adds some forgotten tests and should correctly trigger deployment