### PR TITLE
Implement diff as message command

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -14,7 +14,6 @@ use tokio::sync::MutexGuard;
 
 use chrono::{DateTime, Utc};
 
-use crate::managers::command::CommandManager;
 use crate::{
     cache::*,
     commands::compile::handle_request,
@@ -74,9 +73,8 @@ impl EventHandler for Handler {
     async fn guild_create(&self, ctx: Context, guild: Guild) {
         let data = ctx.data.read().await;
 
-        // in debug, we'll clean out old commands and register on a guild-per-guild basis
+        // in debug, we'll register on a guild-per-guild basis
         if cfg!(debug_assertions) {
-            CommandManager::remove_guild_commands(&ctx, &guild).await;
             let mut cmd_mgr = data.get::<CommandCache>().unwrap().write().await;
             cmd_mgr.register_commands_guild(&ctx, &guild).await;
         }

--- a/src/slashcmds/diff_msg.rs
+++ b/src/slashcmds/diff_msg.rs
@@ -1,0 +1,100 @@
+use std::time::Duration;
+
+use serenity::{
+    framework::standard::CommandResult,
+    model::interactions::application_command::ApplicationCommandInteraction, prelude::*,
+};
+
+use crate::slashcmds::diff::run_diff;
+use crate::{
+    cache::{DiffCommandCache, DiffCommandEntry},
+    slashcmds::diff::get_code_block_or_content,
+    utls::constants::COLOR_OKAY,
+    utls::discordhelpers::interactions,
+};
+
+pub async fn diff_msg(ctx: &Context, msg: &ApplicationCommandInteraction) -> CommandResult {
+    let data = ctx.data.read().await;
+    let diff_cache_lock = data.get::<DiffCommandCache>().unwrap();
+
+    let is_first = {
+        let mut diff_cache = diff_cache_lock.lock().await;
+        if let Some(entry) = diff_cache.get_mut(msg.user.id.as_u64()) {
+            entry.is_expired()
+        } else {
+            true
+        }
+    };
+
+    if is_first {
+        let (_, new_msg) = msg.data.resolved.messages.iter().next().unwrap();
+
+        msg.create_interaction_response(&ctx.http, |resp| {
+            interactions::create_diff_select_response(resp)
+        })
+        .await
+        .unwrap();
+        {
+            let mut diff_cache = diff_cache_lock.lock().await;
+            let content = get_code_block_or_content(&new_msg.content, &new_msg.author).await?;
+            diff_cache.insert(msg.user.id.0, DiffCommandEntry::new(&content, msg));
+        }
+        let resp = msg.get_interaction_response(&ctx.http).await?;
+        let button_resp = resp
+            .await_component_interaction(&ctx.shard)
+            .timeout(Duration::from_secs(30))
+            .author_id(msg.user.id.0)
+            .await;
+        if let Some(interaction) = button_resp {
+            interaction.defer(&ctx.http).await?;
+            let mut diff_cache = diff_cache_lock.lock().await;
+            diff_cache.remove(interaction.user.id.as_u64());
+            msg.edit_original_interaction_response(&ctx.http, |edit| {
+                edit.set_embeds(Vec::new())
+                    .embed(|emb| {
+                        emb.color(COLOR_OKAY).description(
+                            "Interaction cancelled, you may safely dismiss this message",
+                        )
+                    })
+                    .components(|cmps| cmps.set_action_rows(Vec::new()))
+            })
+            .await?;
+        } else {
+            // Button expired
+            msg.edit_original_interaction_response(&ctx.http, |edit| {
+                edit.set_embeds(Vec::new())
+                    .embed(|emb| {
+                        emb.color(COLOR_OKAY).description(
+                            "Interaction expired, you may safely dismiss this messsage",
+                        )
+                    })
+                    .components(|cmps| cmps.set_action_rows(Vec::new()))
+            })
+            .await?;
+        }
+        return Ok(());
+    }
+
+    // we can execute our diff now
+
+    let (entry, first_interaction) = {
+        let mut diff_cache = diff_cache_lock.lock().await;
+        let entry = diff_cache.remove(msg.user.id.as_u64()).unwrap();
+        (entry.content, entry.first_interaction)
+    };
+
+    if let Some((_, new_msg)) = msg.data.resolved.messages.iter().next() {
+        let content = get_code_block_or_content(&new_msg.content, &new_msg.author).await?;
+        let output = run_diff(&entry, &content);
+
+        first_interaction
+            .edit_original_interaction_response(&ctx.http, interactions::edit_to_dismiss_response)
+            .await?;
+
+        msg.create_interaction_response(&ctx.http, |resp| {
+            interactions::create_diff_response(resp, &output)
+        })
+        .await?;
+    }
+    Ok(())
+}

--- a/src/slashcmds/mod.rs
+++ b/src/slashcmds/mod.rs
@@ -2,6 +2,7 @@ pub mod asm;
 pub mod compile;
 pub mod cpp;
 pub mod diff;
+pub mod diff_msg;
 pub mod format;
 pub mod help;
 pub mod invite;

--- a/src/utls/discordhelpers/interactions.rs
+++ b/src/utls/discordhelpers/interactions.rs
@@ -274,10 +274,58 @@ pub fn create_dismiss_response<'this, 'a>(
         .interaction_response_data(|data| {
             data.set_embeds(Vec::new())
                 .embed(|emb| {
-                    emb.color(COLOR_WARN)
+                    emb.color(COLOR_OKAY)
                         .description("Interaction completed, you may safely dismiss this message.")
                 })
                 .components(|components| components.set_action_rows(Vec::new()))
+        })
+}
+
+pub fn edit_to_dismiss_response(
+    edit: &mut EditInteractionResponse,
+) -> &mut EditInteractionResponse {
+    edit.set_embeds(Vec::new())
+        .embed(|emb| {
+            emb.color(COLOR_OKAY)
+                .description("Interaction completed, you may safely dismiss this message.")
+        })
+        .components(|components| components.set_action_rows(Vec::new()))
+}
+
+pub fn create_diff_select_response<'this, 'a>(
+    resp: &'this mut CreateInteractionResponse<'a>,
+) -> &'this mut CreateInteractionResponse<'a> {
+    resp.kind(InteractionResponseType::ChannelMessageWithSource)
+        .interaction_response_data(|data| {
+            data.flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+                .embed(|emb| {
+                    emb.color(COLOR_WARN).description(
+                        "Please re-run this command on another message to generate a diff",
+                    )
+                })
+                .components(|components| {
+                    components.create_action_row(|row| {
+                        row.create_button(|btn| {
+                            btn.custom_id("cancel")
+                                .label("Cancel")
+                                .style(ButtonStyle::Danger)
+                        })
+                    })
+                })
+        })
+}
+
+pub fn create_diff_response<'this, 'a>(
+    resp: &'this mut CreateInteractionResponse<'a>,
+    output: &str,
+) -> &'this mut CreateInteractionResponse<'a> {
+    resp.kind(InteractionResponseType::ChannelMessageWithSource)
+        .interaction_response_data(|data| {
+            data.embed(|emb| {
+                emb.color(COLOR_OKAY)
+                    .title("Diff completed")
+                    .description(format!("```diff\n{}\n```", output))
+            })
         })
 }
 


### PR DESCRIPTION
This patch brings in the diff functionality as a message command, allowing users to run diffs without having to copy message IDs.

We've also changed the parsing mechanism to grab input from code blocks if it exists, but if there's no code block found it will instead use message content. 