### PR TITLE
Add support to log panics to chat for conveinence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ LOGO_EMOJI_ID=
 ## Usage logging
 COMPILE_LOG=
 JOIN_LOG=
+PANIC_LOG=
 
 ## Top.gg bot voting announcement
 VOTE_CHANNEL=

--- a/src/utls/discordhelpers/embeds.rs
+++ b/src/utls/discordhelpers/embeds.rs
@@ -222,6 +222,13 @@ pub fn build_dblvote_embed(tag: String) -> CreateEmbed {
     embed
 }
 
+pub fn panic_embed(panic_info: String) -> CreateEmbed {
+    let mut embed = CreateEmbed::default();
+    embed.title("Oopsie");
+    embed.description(format!("```\n{}\n```", panic_info));
+    embed
+}
+
 pub fn build_welcome_embed() -> CreateEmbed {
     let mut embed = CreateEmbed::default();
     embed.title("Discord Compiler");


### PR DESCRIPTION
This patch will log any panics to a new #panic-log channel in our support discord. This should allow for faster error identification, preventing me from monitoring logs manually.