### PR TITLE
Allow boot with partial service availability

### DIFF
--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -34,7 +34,13 @@ pub async fn format(ctx: &Context, msg: &Message, mut args: Args) -> CommandResu
 
     let data = ctx.data.read().await;
     let comp_mgr = data.get::<CompilerCache>().unwrap().read().await;
-    let gbolt = &comp_mgr.gbolt;
+    if comp_mgr.gbolt.is_none() {
+        return Err(CommandError::from(
+            "Compiler Explorer service is currently down, please try again later.",
+        ));
+    }
+
+    let gbolt = comp_mgr.gbolt.as_ref().unwrap();
 
     // validate user input
     for format in &gbolt.formats {

--- a/src/commands/formats.rs
+++ b/src/commands/formats.rs
@@ -1,6 +1,6 @@
 use crate::cache::{CompilerCache, ConfigCache};
 use serenity::builder::CreateEmbed;
-use serenity::framework::standard::{macros::command, Args, CommandResult};
+use serenity::framework::standard::{macros::command, Args, CommandError, CommandResult};
 use serenity::model::prelude::*;
 use serenity::prelude::*;
 
@@ -20,13 +20,18 @@ pub async fn formats(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     };
 
     let compiler_manager = data.get::<CompilerCache>().unwrap().read().await;
+    if compiler_manager.gbolt.is_none() {
+        return Err(CommandError::from(
+            "Compiler Explorer service is currently down, please try again later.",
+        ));
+    }
 
     let mut emb = CreateEmbed::default();
     emb.thumbnail(ICON_HELP);
     emb.color(COLOR_OKAY);
     emb.title("Formatters:");
     emb.description(format!("Below is the list of all formatters currently supported, an valid example request can be `{}format rust`, or `{}format clang mozilla`", prefix, prefix));
-    for format in &compiler_manager.gbolt.formats {
+    for format in &compiler_manager.gbolt.as_ref().unwrap().formats {
         let mut output = String::new();
         output.push_str("Styles:\n");
         if format.styles.is_empty() {

--- a/src/commands/languages.rs
+++ b/src/commands/languages.rs
@@ -13,14 +13,17 @@ pub async fn languages(ctx: &Context, msg: &Message, _args: Args) -> CommandResu
     let compiler_manager = compiler_cache.read().await;
 
     let mut items = Vec::new();
-
-    for cache_entry in &compiler_manager.gbolt.cache {
-        items.push(format!("{}*", cache_entry.language.id));
+    if let Some(gbolt) = compiler_manager.gbolt.as_ref() {
+        for cache_entry in &gbolt.cache {
+            items.push(format!("{}*", cache_entry.language.id));
+        }
     }
-    let langs = compiler_manager.wbox.get_languages();
-    for lang in langs {
-        if !items.contains(&lang.name) && !items.contains(&format!("{}*", &lang.name)) {
-            items.push(lang.name);
+    if let Some(wbox) = &compiler_manager.wbox {
+        let langs = wbox.get_languages();
+        for lang in langs {
+            if !items.contains(&lang.name) && !items.contains(&format!("{}*", &lang.name)) {
+                items.push(lang.name);
+            }
         }
     }
 

--- a/src/slashcmds/format.rs
+++ b/src/slashcmds/format.rs
@@ -27,11 +27,15 @@ pub async fn format(ctx: &Context, command: &ApplicationCommandInteraction) -> C
 
     let data = ctx.data.read().await;
     let comp_mgr = data.get::<CompilerCache>().unwrap().read().await;
-    let gbolt = &comp_mgr.gbolt;
+    if comp_mgr.gbolt.is_none() {
+        return Err(CommandError::from(
+            "Compiler Explorer service is currently down, please try again later.",
+        ));
+    }
 
     command
         .create_interaction_response(&ctx.http, |response| {
-            create_formats_interaction(response, &gbolt.formats)
+            create_formats_interaction(response, &comp_mgr.gbolt.as_ref().unwrap().formats)
         })
         .await?;
 
@@ -66,7 +70,10 @@ pub async fn format(ctx: &Context, command: &ApplicationCommandInteraction) -> C
         return Ok(());
     }
 
-    let styles = &gbolt
+    let styles = &comp_mgr
+        .gbolt
+        .as_ref()
+        .unwrap()
         .formats
         .iter()
         .find(|p| p.format_type == formatter)

--- a/src/utls/discordhelpers/interactions.rs
+++ b/src/utls/discordhelpers/interactions.rs
@@ -149,7 +149,8 @@ pub async fn create_compiler_options(
             )))
         }
         RequestHandler::WandBox => {
-            let compilers = compilers.wbox.get_compilers(language).unwrap();
+            let wbox = compilers.wbox.as_ref().unwrap();
+            let compilers = wbox.get_compilers(language).unwrap();
             let mut first = true;
             for compiler in if compilers.len() > 25 {
                 &compilers[..24]
@@ -173,7 +174,7 @@ pub async fn create_compiler_options(
             let mut default = None;
             let mut list = None;
 
-            for cache in &compilers.gbolt.cache {
+            for cache in &compilers.gbolt.as_ref().unwrap().cache {
                 if cache.language.name.to_lowercase() == language {
                     list = Some(
                         cache


### PR DESCRIPTION
This patch should prevent the situation we ran into today where wandbox.org was down for a few hours, which prevented us from functioning at all. Now, we will continue with boot if a service was unable to load and at least retain partial service availability.