### PR TITLE
Assume status-less wandbox compilations are not successful

### DIFF
--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -199,7 +199,11 @@ pub async fn handle_edit_asm(
 }
 
 pub fn is_success_embed(embed: &CreateEmbed) -> bool {
-    embed.0.get("color").unwrap() == COLOR_OKAY
+    if let Some(color) = embed.0.get("color") {
+        color == COLOR_OKAY
+    } else {
+        false
+    }
 }
 
 pub async fn send_completion_react(


### PR DESCRIPTION
Sometimes wandbox will not report a status leading to this call not finding any color on the embed.

If we do not get a status from wandbox assume the compilation failed 