### PR TITLE
Add more compilation information to footer for compilations

### DIFF
--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -114,7 +114,7 @@ pub async fn handle_request(
     let is_success = is_success_embed(&result.1);
     let stats = data_read.get::<StatsManagerCache>().unwrap().lock().await;
     if stats.should_track() {
-        stats.compilation(&result.0, !is_success).await;
+        stats.compilation(&result.0.language, !is_success).await;
     }
 
     let data = ctx.data.read().await;

--- a/src/commands/cpp.rs
+++ b/src/commands/cpp.rs
@@ -5,6 +5,7 @@ use serenity::{
     prelude::*,
 };
 
+use crate::utls::discordhelpers::embeds::EmbedOptions;
 use crate::{
     cache::{CompilerCache, ConfigCache, MessageCache, MessageCacheEntry},
     cppeval::eval::CppEval,
@@ -101,6 +102,7 @@ pub async fn handle_request(
 
     // remove our loading emote
     discordhelpers::delete_bot_reacts(&ctx, msg, loading_reaction).await?;
+    let options = EmbedOptions::new(false, fake_parse.target.clone(), String::default());
 
-    Ok(result.1.to_embed(&author, false))
+    Ok(result.1.to_embed(&author, &options))
 }

--- a/src/slashcmds/cpp.rs
+++ b/src/slashcmds/cpp.rs
@@ -5,6 +5,7 @@ use serenity::{
     model::prelude::*, prelude::*,
 };
 
+use crate::utls::discordhelpers::embeds::EmbedOptions;
 use crate::{
     cache::CompilerCache, cppeval::eval::CppEval, utls::constants::COLOR_OKAY,
     utls::discordhelpers::embeds::ToEmbed, utls::parser::ParserResult,
@@ -59,9 +60,10 @@ pub async fn cpp(ctx: &Context, msg: &ApplicationCommandInteraction) -> CommandR
         let data_read = ctx.data.read().await;
         let compiler_lock = data_read.get::<CompilerCache>().unwrap().read().await;
         let result = compiler_lock.compiler_explorer(&fake_parse).await?;
+        let options = EmbedOptions::new(false, fake_parse.target.clone(), String::default());
 
         msg.edit_original_interaction_response(&ctx.http, |resp| {
-            resp.add_embed(result.1.to_embed(&msg.user, false))
+            resp.add_embed(result.1.to_embed(&msg.user, &options))
         })
         .await?;
     }


### PR DESCRIPTION
This patch allows users to see the language and compiler used for all compilation and assembly requests.

This is useful to understand what default compilers are being used along with what languages others are using for their requests.