### PR TITLE
Fix C printf boilerplate

### DIFF
--- a/src/boilerplate/c.rs
+++ b/src/boilerplate/c.rs
@@ -20,15 +20,15 @@ impl BoilerPlateGenerator for CGenerator {
         let lines = self.input.split('\n');
         for line in lines {
             let trimmed = line.trim();
-            if trimmed.starts_with("using") || trimmed.starts_with("#i") {
+            if trimmed.starts_with("#i") || trimmed.starts_with("#d") {
                 header.push_str(&format!("{}\n", trimmed));
             } else {
                 main_body.push_str(&format!("{}\n", trimmed))
             }
         }
 
-        if main_body.contains("printf") && header.contains("stdio.h") {
-            header.push_str("include <stdio.h>")
+        if main_body.contains("printf") && !header.contains("stdio.h") {
+            header.push_str("#include <stdio.h>")
         }
         format!("{}\nint main(void) {{\n{}return 0;\n}}", header, main_body)
     }


### PR DESCRIPTION
This patch is a regression from #154, C implementation encountered some mindless copy-paste errors.