### PR TITLE
Trying to comply with new `cargo clippy`

### DIFF
--- a/src/boilerplate/c.rs
+++ b/src/boilerplate/c.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use crate::boilerplate::generator::BoilerPlateGenerator;
 use crate::utls::constants::C_LIKE_MAIN_REGEX;
 
@@ -21,9 +23,11 @@ impl BoilerPlateGenerator for CGenerator {
         for line in lines {
             let trimmed = line.trim();
             if trimmed.starts_with("#i") || trimmed.starts_with("#d") {
-                header.push_str(&format!("{}\n", trimmed));
+                // header.push_str(&format!("{}\n", trimmed));
+                writeln!(header, "{}", trimmed).unwrap();
             } else {
-                main_body.push_str(&format!("{}\n", trimmed))
+                // main_body.push_str(&format!("{}\n", trimmed))
+                writeln!(main_body, "{}", trimmed).unwrap();
             }
         }
 

--- a/src/boilerplate/cpp.rs
+++ b/src/boilerplate/cpp.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use crate::boilerplate::generator::BoilerPlateGenerator;
 use crate::utls::constants::C_LIKE_MAIN_REGEX;
 
@@ -21,9 +23,11 @@ impl BoilerPlateGenerator for CppGenerator {
         for line in lines {
             let trimmed = line.trim();
             if trimmed.starts_with("using") || trimmed.starts_with("#i") {
-                header.push_str(&format!("{}\n", trimmed));
+                // header.push_str(&format!("{}\n", trimmed));
+                writeln!(header, "{}", trimmed).unwrap();
             } else {
-                main_body.push_str(&format!("{}\n", trimmed))
+                // main_body.push_str(&format!("{}\n", trimmed))
+                writeln!(main_body, "{}", trimmed).unwrap();
             }
         }
 

--- a/src/boilerplate/csharp.rs
+++ b/src/boilerplate/csharp.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use crate::boilerplate::generator::BoilerPlateGenerator;
 use crate::utls::constants::CSHARP_MAIN_REGEX;
 
@@ -21,9 +23,11 @@ impl BoilerPlateGenerator for CSharpGenerator {
         for line in lines {
             let trimmed = line.trim();
             if trimmed.starts_with("using") {
-                header.push_str(&format!("{}\n", trimmed));
+                // header.push_str(&format!("{}\n", trimmed));
+                writeln!(header, "{}", trimmed).unwrap();
             } else {
-                main_body.push_str(&format!("{}\n", trimmed))
+                // main_body.push_str(&format!("{}\n", trimmed))
+                writeln!(main_body, "{}", trimmed).unwrap();
             }
         }
 

--- a/src/boilerplate/java.rs
+++ b/src/boilerplate/java.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use crate::boilerplate::generator::BoilerPlateGenerator;
 use crate::utls::constants::JAVA_MAIN_REGEX;
 
@@ -21,9 +23,11 @@ impl BoilerPlateGenerator for JavaGenerator {
         for line in lines {
             let trimmed = line.trim();
             if trimmed.starts_with("import") {
-                header.push_str(&format!("{}\n", trimmed));
+                // header.push_str(&format!("{}\n", trimmed));
+                writeln!(header, "{}", trimmed).unwrap();
             } else {
-                main_body.push_str(&format!("{}\n", trimmed))
+                // main_body.push_str(&format!("{}\n", trimmed))
+                writeln!(main_body, "{}", trimmed).unwrap();
             }
         }
 

--- a/src/commands/asm.rs
+++ b/src/commands/asm.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use serenity::{
     client::Context,
     framework::standard::{macros::command, Args, CommandError, CommandResult},
@@ -62,7 +64,8 @@ pub async fn handle_request(
     // Try to load in an attachment
     let (code, ext) = parser::get_message_attachment(&msg.attachments).await?;
     if !code.is_empty() {
-        content.push_str(&format!("\n```{}\n{}\n```\n", ext, code));
+        // content.push_str(&format!("\n```{}\n{}\n```\n", ext, code));
+        writeln!(content, "\n```{}\n{}\n```\n", ext, code).unwrap();
     }
 
     // parse user input

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use serenity::framework::standard::{macros::command, Args, CommandResult};
 
 use crate::cache::{MessageCache, MessageCacheEntry};
@@ -68,7 +70,8 @@ pub async fn handle_request(
     // Try to load in an attachment
     let (code, ext) = parser::get_message_attachment(&msg.attachments).await?;
     if !code.is_empty() {
-        content.push_str(&format!("\n```{}\n{}\n```\n", ext, code));
+        // content.push_str(&format!("\n```{}\n{}\n```\n", ext, code));
+        writeln!(&mut content, "\n```{}\n{}\n```\n", ext, code).unwrap();
     }
 
     // parse user input

--- a/src/commands/formats.rs
+++ b/src/commands/formats.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use crate::cache::{CompilerCache, ConfigCache};
 use serenity::builder::CreateEmbed;
 use serenity::framework::standard::{macros::command, Args, CommandError, CommandResult};
@@ -38,7 +40,8 @@ pub async fn formats(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
             output.push_str("    *(None)*\n");
         }
         for style in &format.styles {
-            output.push_str(&format!("    *- {}*\n", style));
+            // output.push_str(&format!("    *- {}*\n", style));
+            writeln!(output, "    *- {}*", style).unwrap();
         }
         emb.field(&format.format_type, &output, false);
     }

--- a/src/cppeval/eval.rs
+++ b/src/cppeval/eval.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::fmt::Write as _;
 
 #[derive(Debug, Clone)]
 pub struct EvalError {
@@ -70,8 +71,9 @@ impl CppEval {
             let main = capture[1].trim().to_string();
             let rest = self.input.replacen(&main, "", 1).trim().to_string();
 
-            self.output.push_str(&format!("{}\n", rest));
-            self.output.push_str(&format!("{}\n", main));
+            // self.output.push_str(&format!("{}\n", rest));
+            // self.output.push_str(&format!("{}\n", main));
+            writeln!(self.output, "{}\n{}", rest, main).unwrap();
         } else {
             return Err(EvalError::new("No main() specified. Invalid request"));
         }
@@ -177,8 +179,9 @@ impl CppEval {
     }
 
     fn build_main(&mut self, statements: &str) {
-        self.output
-            .push_str(&format!("\nint main (void) {{\n{}\n}}", statements));
+        // self.output
+        //     .push_str(&format!("\nint main (void) {{\n{}\n}}", statements));
+        writeln!(self.output, "\nint main (void) {{\n{}\n}}", statements).unwrap();
     }
 
     /*    fn add_ostreaming(& mut self) {

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,6 +9,7 @@ use serenity::{
     },
     prelude::*,
 };
+use std::env;
 
 use tokio::sync::MutexGuard;
 
@@ -194,9 +195,10 @@ impl EventHandler for Handler {
                         .await;
                     let _ = new_message.delete_reactions(&ctx.http).await;
                     if collector.is_some() {
+                        let prefix = env::var("BOT_PREFIX").expect("Bot prefix is not set!");
                         let emb = match handle_request(
                             ctx.clone(),
-                            format!(";compile\n```{}\n{}\n```", language, code),
+                            format!("{}compile\n```{}\n{}\n```", prefix, language, code),
                             new_message.author.clone(),
                             &new_message,
                         )

--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -78,7 +78,7 @@ impl CompilationManager {
         parser_result: &ParserResult,
         author: &User,
     ) -> Result<(CompilationDetails, CreateEmbed), CommandError> {
-        return match self.resolve_target(&parser_result.target) {
+        match self.resolve_target(&parser_result.target) {
             RequestHandler::CompilerExplorer => {
                 let result = self.compiler_explorer(parser_result).await?;
 
@@ -103,7 +103,7 @@ impl CompilationManager {
                     target
                 )))
             }
-        };
+        }
     }
 
     pub async fn assembly(
@@ -146,7 +146,7 @@ impl CompilationManager {
             &parse_result.target
         };
         let resolution_result = gbolt.resolve(target);
-        return match resolution_result {
+        match resolution_result {
             None => {
                 Err(CommandError::from(format!("Target '{}' either does not produce assembly or is not currently supported on godbolt.org", target)))
             }
@@ -155,7 +155,7 @@ impl CompilationManager {
                 let options = EmbedOptions::new(true, target.to_string(), compiler.name);
                 Ok((compiler.lang, response.to_embed(author, &options)))
             }
-        };
+        }
     }
 
     pub async fn compiler_explorer(
@@ -316,7 +316,7 @@ impl CompilationManager {
 }
 
 fn fix_common_problems(language: &str, code: String) -> String {
-    return match language {
+    match language {
         "java" => {
             // Fix compilations that
             let mut fix_candidate = code.clone();
@@ -328,5 +328,5 @@ fn fix_common_problems(language: &str, code: String) -> String {
             fix_candidate
         }
         _ => code,
-    };
+    }
 }

--- a/src/slashcmds/diff.rs
+++ b/src/slashcmds/diff.rs
@@ -1,3 +1,5 @@
+use std::fmt::Write as _;
+
 use serenity::framework::standard::CommandError;
 use serenity::{
     framework::standard::CommandResult,
@@ -116,7 +118,8 @@ pub fn run_diff(first: &str, second: &str) -> String {
             ChangeTag::Insert => "+",
             ChangeTag::Equal => " ",
         };
-        output.push_str(&format!("{}{}", sign, change));
+        // output.push_str(&format!("{}{}", sign, change));
+        writeln!(output, "{}{}", sign, change).unwrap();
     }
     output
 }

--- a/src/tests/cpp.rs
+++ b/src/tests/cpp.rs
@@ -66,6 +66,6 @@ async fn eval_output_balance() {
     let mut eval = CppEval::new("{ /* {{{ */ }");
     if let Err(e) = eval.evaluate() {
         println!("{}", e);
-        assert!(false, "Parser failed")
+        panic!("Parser failed.");
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,5 @@
 pub mod boilerplate;
 pub mod cpp;
 #[cfg(test)]
-#[cfg_attr(feature = "cargo-clippy", allow(clippy))]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::all))]
 pub mod parser;

--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -18,7 +18,7 @@ async fn standard_parse() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -43,7 +43,7 @@ async fn standard_parse_args() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -63,7 +63,7 @@ async fn standard_parse_url() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -83,7 +83,7 @@ async fn standard_parse_url_args() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -109,7 +109,7 @@ async fn standard_parse_stdin() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -137,7 +137,7 @@ async fn standard_parse_block_stdin() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -163,7 +163,7 @@ async fn standard_parse_deduce_compiler() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -189,7 +189,7 @@ async fn standard_parse_deduce_compiler_upper_case() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -215,7 +215,7 @@ async fn standard_parse_late_deduce_compiler() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -244,7 +244,7 @@ async fn standard_parse_late_deduce_compiler_block_stdin() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -265,7 +265,7 @@ async fn standard_parse_one_line() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -285,7 +285,7 @@ async fn standard_parse_args_one_line() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();

--- a/src/utls/discordhelpers/embeds.rs
+++ b/src/utls/discordhelpers/embeds.rs
@@ -1,4 +1,5 @@
-use std::str;
+use std::fmt::Write as _;
+use std::{env, str};
 
 use serenity::{
     builder::{CreateEmbed, CreateMessage},
@@ -116,7 +117,8 @@ impl ToEmbed for godbolt::GodboltResponse {
                             pieces.push(append.clone());
                             append.clear()
                         }
-                        append.push_str(&format!("{}\n", text));
+                        // append.push_str(&format!("{}\n", text));
+                        writeln!(append, "{}", text).unwrap();
                     }
                 }
             }
@@ -147,17 +149,20 @@ impl ToEmbed for godbolt::GodboltResponse {
         } else {
             let mut output = String::default();
             for line in &self.stdout {
-                output.push_str(&format!("{}\n", line.text));
+                // output.push_str(&format!("{}\n", line.text));
+                writeln!(output, "{}", line.text).unwrap();
             }
 
             let mut errs = String::default();
             if let Some(errors) = self.build_result.unwrap().stderr {
                 for line in errors {
-                    errs.push_str(&format!("{}\n", line.text));
+                    // errs.push_str(&format!("{}\n", line.text));
+                    writeln!(errs, "{}", line.text).unwrap();
                 }
             }
             for line in &self.stderr {
-                errs.push_str(&format!("{}\n", line.text));
+                // errs.push_str(&format!("{}\n", line.text));
+                writeln!(errs, "{}", line.text).unwrap();
             }
 
             let stdout = output.trim();
@@ -265,6 +270,7 @@ pub fn panic_embed(panic_info: String) -> CreateEmbed {
 
 pub fn build_welcome_embed() -> CreateEmbed {
     let mut embed = CreateEmbed::default();
+    let prefix = env::var("BOT_PREFIX").expect("Bot prefix is not set!");
     embed.title("Discord Compiler");
     embed.color(COLOR_OKAY);
     embed.thumbnail(COMPILER_ICON);
@@ -272,7 +278,7 @@ pub fn build_welcome_embed() -> CreateEmbed {
     embed.field("Introduction", "I can take code that you give me and execute it, display generated assembly, or format it!", true);
     embed.field(
         "Example Request",
-        ";compile python\n```py\nprint('hello world')\n```",
+        format!("{}compile python\n```py\nprint('hello world')\n```", prefix),
         true,
     );
     embed.field("Learning Time!", "If you like reading the manuals of things, read our [getting started](https://github.com/Headline/discord-compiler-bot/wiki/Getting-Started) wiki or if you are confident type `;help` to view all commands.", false);

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -15,6 +15,8 @@ use serenity::client::Context;
 use serenity::framework::standard::CommandResult;
 use tokio::sync::MutexGuard;
 
+use std::fmt::Write as _;
+
 pub fn build_menu_items(
     items: Vec<String>,
     items_per_page: usize,
@@ -39,11 +41,18 @@ pub fn build_menu_items(
             if i > items_per_page {
                 break;
             }
-            description.push_str(&format!(
-                "**{}**) {}\n",
+            // description.push_str(&format!(
+            //     "**{}**) {}\n",
+            //     current_page * items_per_page + i + 1,
+            //     item
+            // ))
+            writeln!(
+                description,
+                "**{}**) {}",
                 current_page * items_per_page + i + 1,
                 item
-            ))
+            )
+            .unwrap();
         }
         emb.color(COLOR_OKAY);
         emb.title(title);
@@ -273,7 +282,7 @@ pub fn conform_external_str(input: &str, max_len: usize) -> String {
 }
 
 pub async fn manual_dispatch(http: Arc<Http>, id: u64, emb: CreateEmbed) {
-    match serenity::model::id::ChannelId(id)
+    if let Err(e) = serenity::model::id::ChannelId(id)
         .send_message(&http, |m| {
             m.embed(|mut e| {
                 e.0 = emb.0;
@@ -282,9 +291,8 @@ pub async fn manual_dispatch(http: Arc<Http>, id: u64, emb: CreateEmbed) {
         })
         .await
     {
-        Ok(m) => m,
-        Err(e) => return error!("Unable to dispatch manually: {}", e),
-    };
+        error!("Unable to dispatch manually: {}", e);
+    }
 }
 
 pub async fn send_global_presence(shard_manager: &MutexGuard<'_, ShardManager>, sum: u64) {

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -63,7 +63,7 @@ pub async fn get_components(
     // the syntax highlighting str later.
     if let Some(comp_mngr) = compilation_manager {
         let lang_lookup = comp_mngr.read().await;
-        if let Some(param) = args.get(0) {
+        if let Some(param) = args.first() {
             let lower_param = param.trim().to_lowercase();
             let language = shortname_to_qualified(&lower_param);
             if !matches!(lang_lookup.resolve_target(language), RequestHandler::None) {
@@ -73,7 +73,7 @@ pub async fn get_components(
         }
     } else {
         // no compilation manager, just assume target is supplied
-        if let Some(param) = args.get(0) {
+        if let Some(param) = args.first() {
             let lower_param = param.trim().to_lowercase();
             let language = shortname_to_qualified(&lower_param);
             args.remove(0);
@@ -216,10 +216,10 @@ async fn get_url_code(url: &str, author: &User) -> Result<String, CommandError> 
         }
     };
 
-    return match response.text().await {
+    match response.text().await {
         Ok(t) => Ok(t),
         Err(_e) => Err(CommandError::from("Unable to grab resource")),
-    };
+    }
 }
 
 pub async fn find_code_block(


### PR DESCRIPTION
this comes from:
```ps1
cargo clippy --all-targets --all-features -- -D clippy::all
```

- found many `.push_str(format!(...))` and replaced them with `writeln!(...)`
- some unnecessary `return {...};` (removed "return" and ";")
- `.get(0)` becomes `.first()` on `Vec<>`