### PR TITLE
TypeScript fix & shorthand `ts`

### DIFF
--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -222,7 +222,7 @@ impl CompilationManager {
     }
 
     pub fn resolve_target(&self, target: &str) -> RequestHandler {
-        if target == "scala" || target == "nim" {
+        if target == "scala" || target == "nim" || target == "typescript" {
             return RequestHandler::WandBox;
         }
 

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -18,6 +18,7 @@ pub fn shortname_to_qualified(language: &str) -> &str {
         "cpp" => "c++",
         "rs" => "rust",
         "js" => "javascript",
+        "ts" => "typescript",
         "csharp" => "c#",
         "cs" => "c#",
         "py" => "python",


### PR DESCRIPTION
- Makes TypeScript use [wandbox](https://wandbox.org) instead of [godbolt](https://godbolt.org/)
- Adds the `ts` shorthand for `typescript`