### PR TITLE
Prevent invalid panic logs from obfuscating errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,12 +122,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let http = client.cache_and_http.http.clone();
 
         std::panic::set_hook(Box::new(move |info| {
-            tokio::spawn({
-                let http = http.clone();
-                let plog_parse = plog.parse::<u64>().unwrap();
+            let http = http.clone();
+            if let Ok(plog_parse) = plog.parse::<u64>() {
                 let panic_str = info.to_string();
-                async move { manual_dispatch(http, plog_parse, panic_embed(panic_str)).await }
-            });
+                tokio::spawn({
+                     async move {
+                         manual_dispatch(http, plog_parse, panic_embed(panic_str)).await
+                     }
+                 });
+            }
+            else {
+                warn!("Unable to parse channel id64 from PANIC_LOG, is it valid?");
+            }
             default_panic(info);
         }));
     }


### PR DESCRIPTION
This is a partial fix to an issue described in #183.

An invalid panic log could create an error that is difficult to understand without prior knowledge of the system. This patch should make incorrectly formatted panic log IDs more obvious.