### PR TITLE
Add bash alias to fully qualify wandbox.org name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -126,12 +126,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             if let Ok(plog_parse) = plog.parse::<u64>() {
                 let panic_str = info.to_string();
                 tokio::spawn({
-                     async move {
-                         manual_dispatch(http, plog_parse, panic_embed(panic_str)).await
-                     }
-                 });
-            }
-            else {
+                    async move { manual_dispatch(http, plog_parse, panic_embed(panic_str)).await }
+                });
+            } else {
                 warn!("Unable to parse channel id64 from PANIC_LOG, is it valid?");
             }
             default_panic(info);

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -22,6 +22,7 @@ pub fn shortname_to_qualified(language: &str) -> &str {
         "csharp" => "c#",
         "cs" => "c#",
         "py" => "python",
+        "bash" => "bash script",
         _ => language,
     }
 }


### PR DESCRIPTION
Fixes #165 

Wandbox's compilations for bash would fail to identify `bash` as a language and instead would fallback on a compiler entitled `bash`. This change properly aliases `bash` to `Bash Script` so language lookup can succeed when needed.