### PR TITLE
Check for existence of build result 

### DIFF
--- a/src/utls/discordhelpers/embeds.rs
+++ b/src/utls/discordhelpers/embeds.rs
@@ -149,19 +149,19 @@ impl ToEmbed for godbolt::GodboltResponse {
         } else {
             let mut output = String::default();
             for line in &self.stdout {
-                // output.push_str(&format!("{}\n", line.text));
                 writeln!(output, "{}", line.text).unwrap();
             }
 
             let mut errs = String::default();
-            if let Some(errors) = self.build_result.unwrap().stderr {
-                for line in errors {
-                    // errs.push_str(&format!("{}\n", line.text));
-                    writeln!(errs, "{}", line.text).unwrap();
+            if let Some(build_result) = self.build_result {
+                if let Some(errors) = build_result.stderr {
+                    for line in errors {
+                        writeln!(errs, "{}", line.text).unwrap();
+                    }
                 }
             }
+
             for line in &self.stderr {
-                // errs.push_str(&format!("{}\n", line.text));
                 writeln!(errs, "{}", line.text).unwrap();
             }
 


### PR DESCRIPTION
A missing check was added to prevent panicking on results from godbolt.org without a build result