### PR TITLE
Do not conform asm as external strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "discord-compiler-bot"
 description = "Discord bot to compile your spaghetti code."
-version = "3.5.1"
+version = "3.5.2"
 authors = ["Michael Flaherty (Headline#9999)"]
 edition = "2018"
 build = "src/build.rs"

--- a/src/utls/discordhelpers/embeds.rs
+++ b/src/utls/discordhelpers/embeds.rs
@@ -128,7 +128,7 @@ impl ToEmbed for godbolt::GodboltResponse {
             for str in pieces {
                 let title = format!("Assembly Output Pt. {}", i);
 
-                let piece = discordhelpers::conform_external_str(&str, MAX_OUTPUT_LEN);
+                let piece = str.replace('`', "\u{200B}`");
                 embed.field(&title, format!("```x86asm\n{}\n```", &piece), false);
                 output = true;
                 i += 1;
@@ -140,7 +140,7 @@ impl ToEmbed for godbolt::GodboltResponse {
                     String::from("Assembly Output")
                 };
 
-                let str = discordhelpers::conform_external_str(&append, MAX_OUTPUT_LEN);
+                let str = append.replace('`', "\u{200B}`");
                 embed.field(&title, format!("```x86asm\n{}\n```", &str), false);
                 output = true;
             }


### PR DESCRIPTION
This was a regression introduced by 6c397b7.

The length limit for external strings is less than discord's embed limit, so we'd unintentionally truncate assembly requests.

Fixes #195 