### PR TITLE
Update dependencies and Rust toolchain version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ chrono = "0.4.19"
 
 
 [dependencies.serenity]
-version = "=0.11.1"
+version = "=0.11.5"
 default-features = false
 features = ["collector", "gateway", "builder", "standard_framework", "http", "model", "client", "framework", "utils", "rustls_backend"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,20 +15,20 @@ reqwest = { version = "0.11" }
 dotenv = "0.15.0"
 regex = "1"
 log = "0.4"
-pretty_env_logger = "0.3"
+pretty_env_logger = "0.4.0"
 strip-ansi-escapes = "0.1.0"
 serde = { version = "1.0.*", features = ["derive"] }
 serde_json = "1.0"
 lru-cache = "0.1"
 async-trait = "0.1"
 content_inspector = "0.2"
-shell-words = "0.1"
+shell-words = "1.1.0"
 const_format = "0.2"
 lazy_static = "1.4.0"
 similar = "2.1.0"
 
 #tests
-indoc = "1.0.3"
+indoc = "2.0.0"
 test-context = "0.1"
 #dbl
 dbl-rs = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "discord-compiler-bot"
 description = "Discord bot to compile your spaghetti code."
-version = "3.5.2"
+version = "3.5.3"
 authors = ["Michael Flaherty (Headline#9999)"]
-edition = "2018"
+edition = "2021"
 build = "src/build.rs"
 
 [dev-dependencies]
@@ -26,6 +26,7 @@ shell-words = "0.1"
 const_format = "0.2"
 lazy_static = "1.4.0"
 similar = "2.1.0"
+
 #tests
 indoc = "1.0.3"
 test-context = "0.1"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -16,8 +16,8 @@ use crate::utls::blocklist::Blocklist;
 use crate::managers::command::CommandManager;
 use crate::managers::compilation::CompilationManager;
 use lru_cache::LruCache;
+use serenity::model::application::interaction::application_command::ApplicationCommandInteraction;
 use serenity::model::channel::Message;
-use serenity::model::interactions::application_command::ApplicationCommandInteraction;
 
 /** Caching **/
 

--- a/src/commands/asm.rs
+++ b/src/commands/asm.rs
@@ -20,10 +20,13 @@ use crate::utls::parser;
 #[bucket = "nospam"]
 pub async fn asm(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     let emb = handle_request(ctx.clone(), msg.content.clone(), msg.author.clone(), msg).await?;
-    let mut emb_msg = embeds::embed_message(emb);
+    let emb_msg = embeds::embed_message(emb);
     let asm_embed = msg
         .channel_id
-        .send_message(&ctx.http, |_| &mut emb_msg)
+        .send_message(&ctx.http, |e| {
+            *e = emb_msg;
+            e
+        })
         .await?;
 
     // Success/fail react

--- a/src/commands/botinfo.rs
+++ b/src/commands/botinfo.rs
@@ -62,7 +62,7 @@ pub async fn botinfo(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
                 );
 
                 e.fields(vec![
-                    ("Language", "Rust 2018", false),
+                    ("Language", "Rust 2021", false),
                     ("Software Version", env!("CARGO_PKG_VERSION"), false),
                     ("Author", env!("CARGO_PKG_AUTHORS"), false),
                     ("Build Information", str.as_str(), false),

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -27,10 +27,13 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     let embed = handle_request(ctx.clone(), msg.content.clone(), msg.author.clone(), msg).await?;
 
     // Send our final embed
-    let mut message = embeds::embed_message(embed);
+    let message = embeds::embed_message(embed);
     let compilation_embed = msg
         .channel_id
-        .send_message(&ctx.http, |_| &mut message)
+        .send_message(&ctx.http, |e| {
+            *e = message;
+            e
+        })
         .await?;
 
     // Success/fail react

--- a/src/commands/cpp.rs
+++ b/src/commands/cpp.rs
@@ -20,12 +20,15 @@ use crate::{
 #[bucket = "nospam"]
 pub async fn cpp(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     let emb = handle_request(ctx.clone(), msg.content.clone(), msg.author.clone(), msg).await?;
-    let mut emb_msg = embeds::embed_message(emb);
+    let emb_msg = embeds::embed_message(emb);
 
     // Dispatch our request
     let compilation_embed = msg
         .channel_id
-        .send_message(&ctx.http, |_| &mut emb_msg)
+        .send_message(&ctx.http, |e| {
+            *e = emb_msg;
+            e
+        })
         .await?;
 
     // add delete cache

--- a/src/commands/formats.rs
+++ b/src/commands/formats.rs
@@ -46,9 +46,12 @@ pub async fn formats(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
         emb.field(&format.format_type, &output, false);
     }
 
-    let mut emb_msg = embeds::embed_message(emb);
+    let emb_msg = embeds::embed_message(emb);
     msg.channel_id
-        .send_message(&ctx.http, |_| &mut emb_msg)
+        .send_message(&ctx.http, |e| {
+            *e = emb_msg;
+            e
+        })
         .await?;
 
     return Ok(());

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -121,9 +121,12 @@ pub async fn help(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
 
         emb.description(description);
 
-        let mut emb_msg = embeds::embed_message(emb);
+        let emb_msg = embeds::embed_message(emb);
         msg.channel_id
-            .send_message(&ctx.http, |_| &mut emb_msg)
+            .send_message(&ctx.http, |e| {
+                *e = emb_msg;
+                e
+            })
             .await?;
 
         return Ok(());

--- a/src/commands/invite.rs
+++ b/src/commands/invite.rs
@@ -12,9 +12,12 @@ pub async fn invite(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
 
     let emb = embeds::build_invite_embed(&invite);
 
-    let mut emb_msg = embeds::embed_message(emb);
+    let emb_msg = embeds::embed_message(emb);
     msg.channel_id
-        .send_message(&ctx.http, |_| &mut emb_msg)
+        .send_message(&ctx.http, |e| {
+            *e = emb_msg;
+            e
+        })
         .await?;
 
     Ok(())

--- a/src/managers/command.rs
+++ b/src/managers/command.rs
@@ -2,15 +2,11 @@ use crate::cache::StatsManagerCache;
 use crate::slashcmds;
 
 use serenity::{
-    builder::CreateApplicationCommand,
-    client::Context,
-    framework::standard::CommandResult,
-    model::{
-        guild::Guild, interactions::application_command::ApplicationCommand,
-        interactions::application_command::ApplicationCommandInteraction,
-        interactions::application_command::ApplicationCommandOptionType,
-        interactions::application_command::ApplicationCommandType,
-    },
+    builder::CreateApplicationCommand, client::Context, framework::standard::CommandResult,
+    model::application::command::Command, model::application::command::CommandOptionType,
+    model::application::command::CommandType,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
+    model::guild::Guild,
 };
 
 pub struct CommandManager {
@@ -52,7 +48,7 @@ impl CommandManager {
             "invite" => slashcmds::invite::invite(ctx, command).await,
             "format" | "format [beta]" => slashcmds::format::format(ctx, command).await,
             "diff" | "diff [beta]" => {
-                if command.data.kind == ApplicationCommandType::Message {
+                if command.data.kind == CommandType::Message {
                     slashcmds::diff_msg::diff_msg(ctx, command).await
                 } else {
                     slashcmds::diff::diff(ctx, command).await
@@ -90,7 +86,7 @@ impl CommandManager {
         }
         self.commands_registered = true;
 
-        match ApplicationCommand::set_global_application_commands(&ctx.http, |setter| {
+        match Command::set_global_application_commands(&ctx.http, |setter| {
             setter.set_application_commands(self.commands.clone())
         })
         .await
@@ -104,7 +100,7 @@ impl CommandManager {
         let mut cmds = Vec::new();
 
         let mut cmd = CreateApplicationCommand::default();
-        cmd.kind(ApplicationCommandType::Message).name(format!(
+        cmd.kind(CommandType::Message).name(format!(
             "Compile{}",
             if cfg!(debug_assertions) {
                 " [BETA]"
@@ -115,7 +111,7 @@ impl CommandManager {
         cmds.push(cmd);
 
         cmd = CreateApplicationCommand::default();
-        cmd.kind(ApplicationCommandType::Message).name(format!(
+        cmd.kind(CommandType::Message).name(format!(
             "Assembly{}",
             if cfg!(debug_assertions) {
                 " [BETA]"
@@ -126,7 +122,7 @@ impl CommandManager {
         cmds.push(cmd);
 
         cmd = CreateApplicationCommand::default();
-        cmd.kind(ApplicationCommandType::Message).name(format!(
+        cmd.kind(CommandType::Message).name(format!(
             "Format{}",
             if cfg!(debug_assertions) {
                 " [BETA]"
@@ -137,7 +133,7 @@ impl CommandManager {
         cmds.push(cmd);
 
         cmd = CreateApplicationCommand::default();
-        cmd.kind(ApplicationCommandType::Message).name(format!(
+        cmd.kind(CommandType::Message).name(format!(
             "Diff{}",
             if cfg!(debug_assertions) {
                 " [BETA]"
@@ -148,49 +144,49 @@ impl CommandManager {
         cmds.push(cmd);
 
         cmd = CreateApplicationCommand::default();
-        cmd.kind(ApplicationCommandType::ChatInput)
+        cmd.kind(CommandType::ChatInput)
             .name("help")
             .description("Information on how to use the compiler");
         cmds.push(cmd);
 
         cmd = CreateApplicationCommand::default();
-        cmd.kind(ApplicationCommandType::ChatInput)
+        cmd.kind(CommandType::ChatInput)
             .name("invite")
             .description("Grab my invite link to invite me to your server");
         cmds.push(cmd);
 
         cmd = CreateApplicationCommand::default();
-        cmd.kind(ApplicationCommandType::ChatInput)
+        cmd.kind(CommandType::ChatInput)
             .name("ping")
             .description("Test my ping to Discord's endpoint");
         cmds.push(cmd);
 
         cmd = CreateApplicationCommand::default();
-        cmd.kind(ApplicationCommandType::ChatInput)
+        cmd.kind(CommandType::ChatInput)
             .name("cpp")
             .description("Shorthand C++ compilation using geordi-like syntax")
             .create_option(|opt| {
                 opt.required(false)
                     .name("input")
-                    .kind(ApplicationCommandOptionType::String)
+                    .kind(CommandOptionType::String)
                     .description("Geordi-like input")
             });
         cmds.push(cmd);
 
         cmd = CreateApplicationCommand::default();
-        cmd.kind(ApplicationCommandType::ChatInput)
+        cmd.kind(CommandType::ChatInput)
             .name("diff")
             .description("Posts a diff of two message code blocks")
             .create_option(|opt| {
                 opt.required(true)
                     .name("message1")
-                    .kind(ApplicationCommandOptionType::String)
+                    .kind(CommandOptionType::String)
                     .description("Message id of first code-block")
             })
             .create_option(|opt| {
                 opt.required(true)
                     .name("message2")
-                    .kind(ApplicationCommandOptionType::String)
+                    .kind(CommandOptionType::String)
                     .description("Message id of second code-block")
             });
         cmds.push(cmd);

--- a/src/slashcmds/asm.rs
+++ b/src/slashcmds/asm.rs
@@ -1,7 +1,7 @@
 use serenity::{
     client::Context,
     framework::standard::{CommandError, CommandResult},
-    model::interactions::application_command::ApplicationCommandInteraction,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
 };
 
 use crate::{

--- a/src/slashcmds/compile.rs
+++ b/src/slashcmds/compile.rs
@@ -1,6 +1,6 @@
 use serenity::{
     client::Context, framework::standard::CommandError, framework::standard::CommandResult,
-    model::interactions::application_command::ApplicationCommandInteraction,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
 };
 
 use tokio::sync::RwLockReadGuard;

--- a/src/slashcmds/cpp.rs
+++ b/src/slashcmds/cpp.rs
@@ -1,8 +1,8 @@
 use serenity::{
-    framework::standard::CommandResult,
-    model::interactions::application_command::ApplicationCommandInteraction,
-    model::interactions::application_command::ApplicationCommandInteractionDataOptionValue,
-    model::prelude::*, prelude::*,
+    client::Context, framework::standard::CommandResult,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
+    model::application::interaction::application_command::CommandDataOptionValue,
+    model::application::interaction::InteractionResponseType,
 };
 
 use crate::utls::discordhelpers::embeds::EmbedOptions;
@@ -44,7 +44,7 @@ pub async fn cpp(ctx: &Context, msg: &ApplicationCommandInteraction) -> CommandR
         .as_ref()
         .expect("Expected data option value");
 
-    if let ApplicationCommandInteractionDataOptionValue::String(input) = geordi_input {
+    if let CommandDataOptionValue::String(input) = geordi_input {
         let mut eval = CppEval::new(input);
         let out = eval.evaluate()?;
 

--- a/src/slashcmds/diff.rs
+++ b/src/slashcmds/diff.rs
@@ -3,9 +3,9 @@ use std::fmt::Write as _;
 use serenity::framework::standard::CommandError;
 use serenity::{
     framework::standard::CommandResult,
-    model::interactions::application_command::ApplicationCommandInteraction,
-    model::interactions::application_command::ApplicationCommandInteractionDataOptionValue,
-    model::prelude::*, prelude::*,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
+    model::application::interaction::application_command::CommandDataOptionValue,
+    model::application::interaction::MessageFlags, model::prelude::*, prelude::*,
 };
 
 use similar::ChangeTag;
@@ -35,11 +35,11 @@ pub async fn diff(ctx: &Context, msg: &ApplicationCommandInteraction) -> Command
         .expect("Expected data option value");
 
     let mut message1_parse = None;
-    if let ApplicationCommandInteractionDataOptionValue::String(input) = message1 {
+    if let CommandDataOptionValue::String(input) = message1 {
         message1_parse = input.parse::<u64>().ok();
     }
     let mut message2_parse = None;
-    if let ApplicationCommandInteractionDataOptionValue::String(input) = message2 {
+    if let CommandDataOptionValue::String(input) = message2 {
         message2_parse = input.parse::<u64>().ok();
     }
 
@@ -54,7 +54,7 @@ pub async fn diff(ctx: &Context, msg: &ApplicationCommandInteraction) -> Command
                         User Settings > Advanced tab",
                     )
                 })
-                .flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+                .flags(MessageFlags::EPHEMERAL)
             })
         })
         .await?;
@@ -80,7 +80,7 @@ pub async fn diff(ctx: &Context, msg: &ApplicationCommandInteraction) -> Command
                         this channel and the Message IDs are correct.",
                     )
                 })
-                .flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+                .flags(MessageFlags::EPHEMERAL)
             })
         })
         .await?;

--- a/src/slashcmds/diff_msg.rs
+++ b/src/slashcmds/diff_msg.rs
@@ -2,7 +2,8 @@ use std::time::Duration;
 
 use serenity::{
     framework::standard::CommandResult,
-    model::interactions::application_command::ApplicationCommandInteraction, prelude::*,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
+    prelude::*,
 };
 
 use crate::slashcmds::diff::run_diff;

--- a/src/slashcmds/format.rs
+++ b/src/slashcmds/format.rs
@@ -7,9 +7,10 @@ use godbolt::{Format, Godbolt};
 use serenity::{
     builder::{CreateInteractionResponse, EditInteractionResponse},
     framework::standard::{CommandError, CommandResult},
-    model::interactions::application_command::ApplicationCommandInteraction,
-    model::interactions::message_component::ButtonStyle,
-    model::prelude::*,
+    model::application::component::ButtonStyle,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
+    model::application::interaction::InteractionResponseType,
+    model::application::interaction::MessageFlags,
     prelude::*,
 };
 use std::time::Duration;
@@ -200,7 +201,7 @@ fn create_formats_interaction<'this, 'a>(
         .kind(InteractionResponseType::ChannelMessageWithSource)
         .interaction_response_data(|data| {
             data.content("Select a formatter to use:")
-                .flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+                .flags(MessageFlags::EPHEMERAL)
                 .components(|cmps| {
                     cmps.create_action_row(|row| {
                         row.create_select_menu(|menu| {

--- a/src/slashcmds/help.rs
+++ b/src/slashcmds/help.rs
@@ -1,7 +1,7 @@
 use serenity::{
     client::Context, framework::standard::CommandResult,
-    model::interactions::application_command::ApplicationCommandInteraction,
-    model::prelude::message_component::ButtonStyle,
+    model::application::component::ButtonStyle,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
 };
 
 use crate::{cache::ConfigCache, utls::constants::*};

--- a/src/slashcmds/invite.rs
+++ b/src/slashcmds/invite.rs
@@ -1,7 +1,7 @@
 use serenity::{
     framework::standard::CommandResult,
-    model::interactions::application_command::ApplicationCommandInteraction, model::prelude::*,
-    prelude::*,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
+    model::application::interaction::InteractionResponseType, prelude::*,
 };
 
 use crate::{cache::ConfigCache, utls::discordhelpers::embeds};

--- a/src/slashcmds/ping.rs
+++ b/src/slashcmds/ping.rs
@@ -1,7 +1,7 @@
 use serenity::{
     framework::standard::CommandResult,
-    model::interactions::application_command::ApplicationCommandInteraction, model::prelude::*,
-    prelude::*,
+    model::application::interaction::application_command::ApplicationCommandInteraction,
+    model::application::interaction::InteractionResponseType, prelude::*,
 };
 
 use std::time::Instant;

--- a/src/utls/discordhelpers/interactions.rs
+++ b/src/utls/discordhelpers/interactions.rs
@@ -7,13 +7,11 @@ use serenity::{
     builder::{CreateComponents, CreateEmbed, CreateInteractionResponse, CreateSelectMenuOption},
     client::Context,
     framework::standard::CommandError,
-    model::interactions::application_command::ApplicationCommandInteraction,
-    model::interactions::message_component::{ActionRowComponent, ButtonStyle, InputTextStyle},
-    model::interactions::{
-        InteractionApplicationCommandCallbackDataFlags, InteractionResponseType,
-    },
-    model::prelude::message_component::MessageComponentInteraction,
-    model::prelude::modal::ModalSubmitInteraction,
+    model::application::component::{ActionRowComponent, ButtonStyle, InputTextStyle},
+    model::application::interaction::application_command::ApplicationCommandInteraction,
+    model::application::interaction::message_component::MessageComponentInteraction,
+    model::application::interaction::modal::ModalSubmitInteraction,
+    model::application::interaction::{InteractionResponseType, MessageFlags},
 };
 
 use crate::cache::ConfigCache;
@@ -66,7 +64,7 @@ pub async fn create_more_options_panel(
         .create_interaction_response(&ctx.http, |resp| {
             resp.kind(InteractionResponseType::Modal)
                 .interaction_response_data(|data| {
-                    data.flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+                    data.flags(MessageFlags::EPHEMERAL)
                         .custom_id("more_options_panel")
                         .content("Select a compiler:")
                         .title("More options")
@@ -252,7 +250,7 @@ pub fn create_language_interaction<'this, 'a>(
 ) -> &'this mut CreateInteractionResponse<'a> {
     resp.kind(InteractionResponseType::ChannelMessageWithSource)
         .interaction_response_data(|data| {
-            data.flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+            data.flags(MessageFlags::EPHEMERAL)
                 .content("Select a language:")
                 .components(|components| {
                     components.create_action_row(|row| {
@@ -303,7 +301,7 @@ pub fn create_diff_select_response<'this, 'a>(
 ) -> &'this mut CreateInteractionResponse<'a> {
     resp.kind(InteractionResponseType::ChannelMessageWithSource)
         .interaction_response_data(|data| {
-            data.flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+            data.flags(MessageFlags::EPHEMERAL)
                 .embed(|emb| {
                     emb.color(COLOR_WARN).description(
                         "Please re-run this command on another message to generate a diff",
@@ -362,9 +360,7 @@ where
             command
                 .create_interaction_response(&ctx.http, |resp| {
                     resp.kind(InteractionResponseType::DeferredChannelMessageWithSource)
-                        .interaction_response_data(|data| {
-                            data.flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
-                        })
+                        .interaction_response_data(|data| data.flags(MessageFlags::EPHEMERAL))
                 })
                 .await?;
             return Err(CommandError::from("Unable to find a codeblock to compile!"));
@@ -407,7 +403,7 @@ where
                     .interaction_response_data(|data| {
                         let compile_components = create_compile_panel(options);
 
-                        data.flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+                        data.flags(MessageFlags::EPHEMERAL)
                             .content("Select a compiler:")
                             .set_components(compile_components)
                     })

--- a/src/utls/discordhelpers/menu.rs
+++ b/src/utls/discordhelpers/menu.rs
@@ -2,8 +2,8 @@ use futures_util::StreamExt;
 use serenity::builder::{CreateComponents, CreateEmbed};
 use serenity::client::Context;
 use serenity::framework::standard::CommandError;
+use serenity::model::application::component::ButtonStyle;
 use serenity::model::channel::Message;
-use serenity::model::interactions::message_component::ButtonStyle;
 use std::time::Duration;
 
 pub struct Menu {

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -284,8 +284,8 @@ pub fn conform_external_str(input: &str, max_len: usize) -> String {
 pub async fn manual_dispatch(http: Arc<Http>, id: u64, emb: CreateEmbed) {
     if let Err(e) = serenity::model::id::ChannelId(id)
         .send_message(&http, |m| {
-            m.embed(|mut e| {
-                e.0 = emb.0;
+            m.embed(|e| {
+                *e = emb;
                 e
             })
         })


### PR DESCRIPTION
This brings us up to date on Serenity and a few of our other dependencies. 

No features for this patch, but lots of refactoring to get us away from deprecated Serenity functionality. I do not follow Serenity too closely, but I suspect more breakage in the future and would like to remain at least somewhat up to date.