### PR TITLE
Clean up embed dispatching and fix formatters with no style options

### DIFF
--- a/src/commands/asm.rs
+++ b/src/commands/asm.rs
@@ -20,14 +20,7 @@ use crate::utls::parser;
 #[bucket = "nospam"]
 pub async fn asm(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     let emb = handle_request(ctx.clone(), msg.content.clone(), msg.author.clone(), msg).await?;
-    let emb_msg = embeds::embed_message(emb);
-    let asm_embed = msg
-        .channel_id
-        .send_message(&ctx.http, |e| {
-            *e = emb_msg;
-            e
-        })
-        .await?;
+    let asm_embed = embeds::dispatch_embed(&ctx.http, msg.channel_id, emb).await?;
 
     // Success/fail react
     let compilation_successful = asm_embed.embeds[0].colour.unwrap().0 == COLOR_OKAY;

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -27,14 +27,7 @@ pub async fn compile(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
     let embed = handle_request(ctx.clone(), msg.content.clone(), msg.author.clone(), msg).await?;
 
     // Send our final embed
-    let message = embeds::embed_message(embed);
-    let compilation_embed = msg
-        .channel_id
-        .send_message(&ctx.http, |e| {
-            *e = message;
-            e
-        })
-        .await?;
+    let compilation_embed = embeds::dispatch_embed(&ctx.http, msg.channel_id, embed).await?;
 
     // Success/fail react
     let compilation_successful = compilation_embed.embeds[0].colour.unwrap().0 == COLOR_OKAY;

--- a/src/commands/cpp.rs
+++ b/src/commands/cpp.rs
@@ -20,16 +20,9 @@ use crate::{
 #[bucket = "nospam"]
 pub async fn cpp(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     let emb = handle_request(ctx.clone(), msg.content.clone(), msg.author.clone(), msg).await?;
-    let emb_msg = embeds::embed_message(emb);
 
     // Dispatch our request
-    let compilation_embed = msg
-        .channel_id
-        .send_message(&ctx.http, |e| {
-            *e = emb_msg;
-            e
-        })
-        .await?;
+    let compilation_embed = embeds::dispatch_embed(&ctx.http, msg.channel_id, emb).await?;
 
     // add delete cache
     let data_read = ctx.data.read().await;

--- a/src/commands/formats.rs
+++ b/src/commands/formats.rs
@@ -46,13 +46,7 @@ pub async fn formats(ctx: &Context, msg: &Message, _args: Args) -> CommandResult
         emb.field(&format.format_type, &output, false);
     }
 
-    let emb_msg = embeds::embed_message(emb);
-    msg.channel_id
-        .send_message(&ctx.http, |e| {
-            *e = emb_msg;
-            e
-        })
-        .await?;
+    embeds::dispatch_embed(&ctx.http, msg.channel_id, emb).await?;
 
     return Ok(());
 }

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -120,14 +120,7 @@ pub async fn help(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
         };
 
         emb.description(description);
-
-        let emb_msg = embeds::embed_message(emb);
-        msg.channel_id
-            .send_message(&ctx.http, |e| {
-                *e = emb_msg;
-                e
-            })
-            .await?;
+        embeds::dispatch_embed(&ctx.http, msg.channel_id, emb).await?;
 
         return Ok(());
     }

--- a/src/commands/invite.rs
+++ b/src/commands/invite.rs
@@ -11,14 +11,6 @@ pub async fn invite(ctx: &Context, msg: &Message, _: Args) -> CommandResult {
     let invite = env::var("INVITE_LINK").expect("Expected invite link envvar");
 
     let emb = embeds::build_invite_embed(&invite);
-
-    let emb_msg = embeds::embed_message(emb);
-    msg.channel_id
-        .send_message(&ctx.http, |e| {
-            *e = emb_msg;
-            e
-        })
-        .await?;
-
+    embeds::dispatch_embed(&ctx.http, msg.channel_id, emb).await?;
     Ok(())
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -110,13 +110,12 @@ impl EventHandler for Handler {
             info!("Joining {}", guild.name);
 
             if let Some(system_channel) = guild.system_channel_id {
-                let message = embeds::embed_message(embeds::build_welcome_embed());
-                let _ = system_channel
-                    .send_message(&ctx.http, |e| {
-                        *e = message;
-                        e
-                    })
-                    .await;
+                let _ = embeds::dispatch_embed(
+                    &ctx.http,
+                    system_channel,
+                    embeds::build_welcome_embed(),
+                )
+                .await;
             }
         }
     }
@@ -213,15 +212,11 @@ impl EventHandler for Handler {
                                     &new_message.author,
                                     &format!("{}", e),
                                 );
-                                let emb_msg = embeds::embed_message(emb);
-                                if let Ok(sent) = new_message
-                                    .channel_id
-                                    .send_message(&ctx.http, |e| {
-                                        *e = emb_msg;
-                                        e
-                                    })
-                                    .await
-                                {
+
+                                let sent_fail =
+                                    embeds::dispatch_embed(&ctx.http, new_message.channel_id, emb)
+                                        .await;
+                                if let Ok(sent) = sent_fail {
                                     let mut message_cache =
                                         data.get::<MessageCache>().unwrap().lock().await;
                                     message_cache.insert(
@@ -232,15 +227,8 @@ impl EventHandler for Handler {
                                 return;
                             }
                         };
-                        let mut emb_msg = embeds::embed_message(emb);
-                        emb_msg.reference_message(&new_message);
-                        let _ = new_message
-                            .channel_id
-                            .send_message(&ctx.http, |e| {
-                                *e = emb_msg;
-                                e
-                            })
-                            .await;
+                        let _ =
+                            embeds::dispatch_embed(&ctx.http, new_message.channel_id, emb).await;
                     }
                 }
             }
@@ -366,20 +354,11 @@ pub async fn before(ctx: &Context, msg: &Message, _: &str) -> bool {
             If you feel that this has been done in error, request an unban in the support server.",
             );
 
-            let emb_msg = embeds::embed_message(emb);
-            let msg_response = msg
-                .channel_id
-                .send_message(&ctx.http, |e| {
-                    *e = emb_msg;
-                    e
-                })
-                .await;
-            if msg_response.is_ok() {
-                if author_blocklisted {
-                    warn!("Blocked user {} [{}]", msg.author.tag(), msg.author.id.0);
-                } else {
-                    warn!("Blocked guild {}", guild_id);
-                }
+            let _ = embeds::dispatch_embed(&ctx.http, msg.channel_id, emb).await;
+            if author_blocklisted {
+                warn!("Blocked user {} [{}]", msg.author.tag(), msg.author.id.0);
+            } else {
+                warn!("Blocked guild {}", guild_id);
             }
             return false;
         }
@@ -399,15 +378,8 @@ pub async fn after(
 
     if let Err(e) = command_result {
         let emb = embeds::build_fail_embed(&msg.author, &format!("{}", e));
-        let emb_msg = embeds::embed_message(emb);
-        if let Ok(sent) = msg
-            .channel_id
-            .send_message(&ctx.http, |e| {
-                *e = emb_msg;
-                e
-            })
-            .await
-        {
+        let sent_fail = embeds::dispatch_embed(&ctx.http, msg.channel_id, emb).await;
+        if let Ok(sent) = sent_fail {
             let mut message_cache = data.get::<MessageCache>().unwrap().lock().await;
             message_cache.insert(msg.id.0, MessageCacheEntry::new(sent, msg.clone()));
         }
@@ -424,13 +396,6 @@ pub async fn after(
 pub async fn dispatch_error(ctx: &Context, msg: &Message, error: DispatchError, _: &str) {
     if let DispatchError::Ratelimited(_) = error {
         let emb = embeds::build_fail_embed(&msg.author, "You are sending requests too fast!");
-        let emb_msg = embeds::embed_message(emb);
-        let _ = msg
-            .channel_id
-            .send_message(&ctx.http, |e| {
-                *e = emb_msg;
-                e
-            })
-            .await;
+        let _ = embeds::dispatch_embed(&ctx.http, msg.channel_id, emb).await;
     }
 }

--- a/src/utls/discordhelpers/embeds.rs
+++ b/src/utls/discordhelpers/embeds.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write as _;
 use std::{env, str};
 
+use serenity::http::Http;
 use serenity::{
     builder::{CreateEmbed, CreateMessage},
     client::Context,
@@ -254,6 +255,20 @@ pub fn embed_message(emb: CreateEmbed) -> CreateMessage<'static> {
         e
     });
     msg
+}
+
+pub async fn dispatch_embed(
+    http: impl AsRef<Http>,
+    channel: ChannelId,
+    emb: CreateEmbed,
+) -> serenity::Result<Message> {
+    let emb_msg = embed_message(emb);
+    channel
+        .send_message(http, |e| {
+            *e = emb_msg;
+            e
+        })
+        .await
 }
 
 pub fn build_dblvote_embed(tag: String) -> CreateEmbed {


### PR DESCRIPTION
Before dartformat and gofmt were added to compiler-explorer, we assumed all formatters would have styling options. This patch fixes that issue. Fixes #192 

I've also moved a bunch of message dispatching off to it's own function, it's especially important as we send embeds in a way Serenity does not quite expect. Future breakages may be possible, keeping this in one spot will make updating easier.
