### PR TITLE
Create "View on Godbolt" button

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "discord-compiler-bot"
 description = "Discord bot to compile your spaghetti code."
-version = "3.5.3"
+version = "3.5.4"
 authors = ["Michael Flaherty (Headline#9999)"]
 edition = "2021"
 build = "src/build.rs"

--- a/src/slashcmds/cpp.rs
+++ b/src/slashcmds/cpp.rs
@@ -60,7 +60,7 @@ pub async fn cpp(ctx: &Context, msg: &ApplicationCommandInteraction) -> CommandR
         let data_read = ctx.data.read().await;
         let compiler_lock = data_read.get::<CompilerCache>().unwrap().read().await;
         let result = compiler_lock.compiler_explorer(&fake_parse).await?;
-        let options = EmbedOptions::new(false, fake_parse.target.clone(), String::default());
+        let options = EmbedOptions::new(false, result.0);
 
         msg.edit_original_interaction_response(&ctx.http, |resp| {
             resp.add_embed(result.1.to_embed(&msg.user, &options))


### PR DESCRIPTION
This is a feature request from the #include discord server, it adds a button for users to view their request on godbolt.org. 

The button gets updated on edits, everything should perform as expected. If there are any odd behaviors or configurations that are not represented after clicking the link please file an issue.