### PR TITLE
Ensure locks are closed as soon as possible

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -64,10 +64,12 @@ impl TypeMapKey for LinkAPICache {
     type Value = Arc<RwLock<LinkAPI>>;
 }
 
+#[derive(Clone)]
 pub struct MessageCacheEntry {
     pub our_msg: Message,
     pub original_msg: Message,
 }
+
 impl MessageCacheEntry {
     pub fn new(our_msg: Message, original_msg: Message) -> Self {
         MessageCacheEntry {

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -135,15 +135,17 @@ pub async fn handle_request(
     let _ = discordhelpers::delete_bot_reacts(&ctx, msg, loading_reaction).await;
 
     let is_success = is_success_embed(&result.1);
-    let stats = data_read.get::<StatsManagerCache>().unwrap().lock().await;
-    if stats.should_track() {
-        stats.compilation(&result.0.language, !is_success).await;
+
+    {
+        // stats manager is used in events.rs, lets keep our locks very short
+        let stats = data_read.get::<StatsManagerCache>().unwrap().lock().await;
+        if stats.should_track() {
+            stats.compilation(&result.0.language, !is_success).await;
+        }
     }
 
-    let data = ctx.data.read().await;
-    let config = data.get::<ConfigCache>().unwrap();
+    let config = data_read.get::<ConfigCache>().unwrap();
     let config_lock = config.read().await;
-
     if let Some(log) = config_lock.get("COMPILE_LOG") {
         if let Ok(id) = log.parse::<u64>() {
             let guild = if msg.guild_id.is_some() {


### PR DESCRIPTION
This patch is an attempt at lowering lock contention. Special attention was placed on `Mutex`es and `RwLock::write()`s. 

There is likely a deadlock somewhere, #201 will track this, but I'll do what I can to clean up now with this PR and we'll see how this patch performs..