### PR TITLE
Limit Regex compilations, improve geordi errors, production release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ authors = ["Michael Flaherty (Headline#9999)"]
 edition = "2021"
 build = "src/build.rs"
 
+[profile.production]
+inherits = "release"
+debug = true
+
 [dev-dependencies]
 rusty-hook = "0.11.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "discord-compiler-bot"
 description = "Discord bot to compile your spaghetti code."
-version = "3.5.5"
+version = "3.5.6"
 authors = ["Michael Flaherty (Headline#9999)"]
 edition = "2021"
 build = "src/build.rs"

--- a/src/cppeval/eval.rs
+++ b/src/cppeval/eval.rs
@@ -1,3 +1,4 @@
+use crate::utls::constants::GEORDI_MAIN_REGEX;
 use core::fmt;
 use std::fmt::Write as _;
 
@@ -62,8 +63,7 @@ impl CppEval {
     }
 
     fn do_user_handled(&mut self) -> Result<(), EvalError> {
-        let re = regex::Regex::new(r"(([a-zA-Z]*?)[\s]+main\((.*?)\)[\s]+\{[\s\S]*?\})").unwrap();
-        if let Some(capture) = re.captures_iter(&self.input).next() {
+        if let Some(capture) = GEORDI_MAIN_REGEX.captures_iter(&self.input).next() {
             let main = capture[1].trim().to_string();
             let rest = self.input.replacen(&main, "", 1).trim().to_string();
 

--- a/src/cppeval/eval.rs
+++ b/src/cppeval/eval.rs
@@ -71,7 +71,8 @@ impl CppEval {
             // self.output.push_str(&format!("{}\n", main));
             writeln!(self.output, "{}\n{}", rest, main).unwrap();
         } else {
-            return Err(EvalError::new("No main() specified. Invalid request"));
+            return Err(EvalError::new("Invalid short-hand request, main() not found.\n\n\
+            *This command expects geordi-like input. Did you mean to use ;compile to execute c++ code?*"));
         }
 
         Ok(())

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -36,8 +36,14 @@ lazy_static! {
 
 // Other Regexes
 lazy_static! {
+    pub static ref GEORDI_MAIN_REGEX: Regex =
+        Regex::new(r"(([a-zA-Z]*?)[\s]+main\((.*?)\)[\s]+\{[\s\S]*?\})").unwrap();
     pub static ref JAVA_PUBLIC_CLASS_REGEX: Regex =
         Regex::new("\"[^\"]*?\"|(?P<public>public)[\\s]+?class[\\s]*?").unwrap();
+    pub static ref C_LIKE_INCLUDE_REGEX: Regex =
+        Regex::new("\"[^\"]+\"|(?P<statement>#include\\s<(?P<url>.+?)>)").unwrap();
+    pub static ref CODE_BLOCK_REGEX: Regex =
+        Regex::new(r"```(?:(?P<language>[^\s`]*)\r?\n)?(?P<code>[\s\S]*?)```").unwrap();
 }
 
 /*

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -1,11 +1,10 @@
-use crate::utls::constants::URL_ALLOW_LIST;
+use crate::utls::constants::{CODE_BLOCK_REGEX, C_LIKE_INCLUDE_REGEX, URL_ALLOW_LIST};
 
 use serenity::framework::standard::CommandError;
 use serenity::model::channel::{Attachment, Message};
 use serenity::model::user::User;
 
 use crate::managers::compilation::{CompilationManager, RequestHandler};
-use regex::Regex;
 use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -236,8 +235,7 @@ pub async fn find_code_block(
     haystack: &str,
     author: &User,
 ) -> Result<bool, CommandError> {
-    let re = regex::Regex::new(r"```(?:(?P<language>[^\s`]*)\r?\n)?(?P<code>[\s\S]*?)```").unwrap();
-    let matches = re.captures_iter(haystack);
+    let matches = CODE_BLOCK_REGEX.captures_iter(haystack);
 
     let mut captures = Vec::new();
     let list = matches.enumerate();
@@ -263,8 +261,7 @@ pub async fn find_code_block(
     }
 
     let code_copy = result.code.clone();
-    let include_regex = Regex::new("\"[^\"]+\"|(?P<statement>#include\\s<(?P<url>.+?)>)").unwrap();
-    let matches = include_regex.captures_iter(&code_copy).enumerate();
+    let matches = C_LIKE_INCLUDE_REGEX.captures_iter(&code_copy).enumerate();
     for (_, cap) in matches {
         if let Some(statement) = cap.name("statement") {
             let include_stmt = statement.as_str();


### PR DESCRIPTION
Let's take one at a time

- Limiting regular expression compilations
  - We already had some "static" regular expressions so we don't waste time recompiling expressions, but for some reason our hottest code path was not utilizing this. After this patch, every regular expression is now compiled only once.
- Geordi errors
  - I've seen many times where our `;cpp` command gets confused for `;compile`. This confusion makes sense, our system is not the most intuitive here. This patch creates a friendly warning that `;cpp` is meant for geordi-like input and they may want to use `;compile` instead.
  - There's more to this error, I'm curious if our best strategy moving forward will be to import all programming languages as valid commands, so languages like java can be executed without `;compile java` but instead just `;java`. This would change a ton of our underlying command handling, so I'm biting my tongue on moving forward with this until other changes are made. Let me know if you support this idea.
- Production release profile
  - As you may know I'm currently fighting #201. #202 seems to have mitigated this problem, we have not observed a deadlock since this patch was brought in. I'm still suspecting we've yet to completely quell this issue, so in the mean time we'll be compiling production with optimizations and debug info. Since investigating the suspected deadlock we have been running a pure debug build, now we'll just turn optimizations on and continue observing.