### PR TITLE
Switch JavaScript to use Wandbox instead of GodBolt

### DIFF
--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -232,7 +232,7 @@ impl CompilationManager {
     }
 
     pub fn resolve_target(&self, target: &str) -> RequestHandler {
-        if target == "scala" || target == "nim" || target == "typescript" {
+        if target == "scala" || target == "nim" || target == "typescript" || target == "javascript" {
             return RequestHandler::WandBox;
         }
 


### PR DESCRIPTION
Switches JavaScript to use Wandbox instead of GodBolt; GodBolt has weird issues and includes a `print` function? Also GodBolt doesn't support some node things like `fs` or `setTimeout`