### PR TITLE
Allow edit failures to be dispatched to users as an internal error, prevent empty components on embed send

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -20,7 +20,7 @@ use lru_cache::LruCache;
 use serenity::all::{ApplicationId, CommandInteraction, ShardManager};
 use serenity::model::channel::Message;
 
-/** Caching **/
+/* Caching */
 
 /// Contains bot configuration information provided mostly from environment variables
 pub struct ConfigCache;

--- a/src/commands/asm.rs
+++ b/src/commands/asm.rs
@@ -6,7 +6,6 @@ use serenity::{
 };
 
 use crate::cache::{CompilerCache, ConfigCache, LinkAPICache, MessageCache, MessageCacheEntry};
-use crate::utls::constants::*;
 use crate::utls::discordhelpers;
 
 use crate::managers::compilation::CompilationDetails;
@@ -41,8 +40,7 @@ pub async fn asm(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
     let asm_embed = msg.channel_id.send_message(&ctx.http, new_msg).await?;
 
     // Success/fail react
-    let compilation_successful = asm_embed.embeds[0].colour.unwrap().0 == COLOR_OKAY;
-    discordhelpers::send_completion_react(ctx, &asm_embed, compilation_successful).await?;
+    discordhelpers::send_completion_react(ctx, &asm_embed, compilation_details.success).await?;
 
     let data_read = ctx.data.read().await;
     let mut message_cache = data_read.get::<MessageCache>().unwrap().lock().await;

--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -306,6 +306,7 @@ impl CompilationManager {
 
         builder.build(wbox)?;
         let res = builder.dispatch().await?;
+        details.success = res.status.eq("0");
         Ok((details, res))
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,5 @@
 pub mod boilerplate;
 pub mod cpp;
 #[cfg(test)]
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::all))]
+#[cfg_attr(feature = "clippy", allow(clippy::all))]
 pub mod parser;


### PR DESCRIPTION
What was happening was that a malformed embed structure was causing silent failures during the handling in the edit message code path. Now all errors here will bubble up back to the user.

The source issue was the the EditMessage struct was being created with an empty button (godbolt link) for wandbox requests, causing an error from discord asking for a non-empty component